### PR TITLE
[DEV] Remove deprecated labels.ts and centralize label fetching from database

### DIFF
--- a/app/api/catalog/route.ts
+++ b/app/api/catalog/route.ts
@@ -11,9 +11,9 @@ import {
   getColors,
   getOptionLabels,
   getAllBoxPricesMap,
-  type PriceInfo,
 } from '@/lib/data';
-import type { OptionSetId } from '@/lib/supabase/types';
+import type { PriceInfo } from '@/lib/preorder';
+import type { OptionSetId } from '@/lib/supabase';
 
 /**
  * GET /api/catalog

--- a/app/step-3/page.tsx
+++ b/app/step-3/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useFormStore } from '@/store/formStore';
 import Link from 'next/link';
+import { isValidEmail, isValidPhone, getEmailError, getPhoneError } from '@/lib/preorder';
 
 export default function Step3() {
   const router = useRouter();
@@ -20,43 +21,35 @@ export default function Step3() {
     router.push('/step-2?returnToSummary=true');
   };
 
-  const validateEmail = (value: string) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(value);
-  };
-
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setEmail(value);
     
     // Only show validation error if user has already tried to submit
     if (hasAttemptedSubmit) {
-      if (value && !validateEmail(value)) {
-        setEmailError('Моля, въведете валиден имейл адрес');
-      } else {
-        setEmailError('');
-      }
+      const error = getEmailError(value);
+      setEmailError(error || '');
     }
   };
 
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    // Allow only numbers, +, -, (, ), and spaces
-    const phoneRegex = /^[0-9+\-() ]*$/;
-    if (phoneRegex.test(value)) {
+    // Use shared validation
+    if (isValidPhone(value)) {
       setPhone(value);
       setPhoneError('');
     } else {
-      setPhoneError('Моля, въведете само цифри и символи за форматиране (+, -, (, ), интервал)');
+      const error = getPhoneError(value);
+      setPhoneError(error || '');
     }
   };
 
   const handleContinue = () => {
     setHasAttemptedSubmit(true);
     
-    // Validate email
-    if (email && !validateEmail(email)) {
-      setEmailError('Моля, въведете валиден имейл адрес');
+    // Validate email using shared validation
+    if (email && !isValidEmail(email)) {
+      setEmailError(getEmailError(email) || '');
       return;
     }
     

--- a/components/PriceDisplay.tsx
+++ b/components/PriceDisplay.tsx
@@ -1,24 +1,10 @@
 'use client';
 
-interface PriceInfo {
-  originalPriceEur: number;
-  originalPriceBgn: number;
-  finalPriceEur: number;
-  finalPriceBgn: number;
-  discountPercent: number;
-  discountAmountEur: number;
-  discountAmountBgn: number;
-}
+import type { PriceDisplayInfo } from '@/lib/preorder';
+import { formatPrice } from '@/lib/preorder';
 
 interface PriceDisplayProps {
-  priceInfo: PriceInfo;
-}
-
-/**
- * Format price with 2 decimal places
- */
-function formatPrice(price: number): string {
-  return price.toFixed(2);
+  priceInfo: PriceDisplayInfo;
 }
 
 /**

--- a/docs/supabase-type-generation.md
+++ b/docs/supabase-type-generation.md
@@ -1,0 +1,103 @@
+# Supabase Type Generation
+
+This document describes how to set up automatic TypeScript type generation from the Supabase database schema.
+
+## Why Type Generation?
+
+Currently, database types (like `BoxType` enum) are manually defined in `lib/supabase/types.ts`. This creates a sync burden - when you add a new box type to the database, you must also update the TypeScript type.
+
+With type generation:
+- **Database is the single source of truth**
+- **Types are auto-generated**, not manually maintained
+- **Changes to DB schema automatically update TypeScript types** (after regeneration)
+
+## Setup
+
+### 1. Install Supabase CLI
+
+```bash
+# Option A: Project-local install (recommended)
+pnpm add -D supabase
+
+# Option B: Global install via npm
+npm install -g supabase
+
+# Option C: Using Scoop (Windows)
+scoop bucket add supabase https://github.com/supabase/scoop-bucket.git
+scoop install supabase
+```
+
+### 2. Generate Types
+
+After installing via pnpm, run:
+
+```bash
+# For remote Supabase project
+pnpm exec supabase gen types typescript --project-id YOUR_PROJECT_ID > lib/supabase/database.types.ts
+
+# For local Supabase setup (if using `supabase start`)
+pnpm exec supabase gen types typescript --local > lib/supabase/database.types.ts
+```
+
+### 3. Add to package.json Scripts
+
+```json
+{
+  "scripts": {
+    "db:types": "supabase gen types typescript --project-id YOUR_PROJECT_ID > lib/supabase/database.types.ts",
+    "prebuild": "pnpm db:types",
+    "build": "next build"
+  }
+}
+```
+
+The `prebuild` script ensures types are regenerated before every build.
+
+### 4. Update Type Imports
+
+After generation, update `lib/supabase/types.ts` to import from the generated file:
+
+```typescript
+// lib/supabase/types.ts
+import type { Database } from './database.types';
+
+// Extract types from generated schema
+export type BoxType = Database['public']['Enums']['box_type'];
+export type Tables = Database['public']['Tables'];
+
+// You can also extract table row types
+export type PreorderRow = Tables['preorders']['Row'];
+export type PreorderInsert = Tables['preorders']['Insert'];
+```
+
+## CI/CD Configuration
+
+For automated builds, you'll need:
+
+1. **Environment Variable**: Set `SUPABASE_ACCESS_TOKEN` in your CI environment
+2. **Project ID**: Either hardcode in script or use `SUPABASE_PROJECT_ID` env var
+
+Example GitHub Actions step:
+
+```yaml
+- name: Generate Supabase Types
+  env:
+    SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+  run: pnpm exec supabase gen types typescript --project-id ${{ secrets.SUPABASE_PROJECT_ID }} > lib/supabase/database.types.ts
+```
+
+## Current State
+
+**Status**: Not yet implemented
+
+The current codebase manually defines types in `lib/supabase/types.ts`. This works but requires manual updates when the database schema changes.
+
+## TODO
+
+- [ ] Install Supabase CLI as dev dependency
+- [ ] Generate initial `database.types.ts`
+- [ ] Update `lib/supabase/types.ts` to import from generated file
+- [ ] Add `db:types` script to package.json
+- [ ] Add `prebuild` hook
+- [ ] Configure CI/CD with Supabase access token
+- [ ] Remove manually defined types that are now auto-generated

--- a/lib/data/index.ts
+++ b/lib/data/index.ts
@@ -20,7 +20,6 @@ export {
   calculatePrice,
   formatPrice,
   eurToBgn,
-  type PriceInfo,
 } from './catalog';
 
 // Promo code data

--- a/lib/data/promo.ts
+++ b/lib/data/promo.ts
@@ -4,7 +4,7 @@
  */
 
 import { supabase } from '@/lib/supabase/client';
-import type { PromoCodeRow } from '@/lib/supabase/types';
+import type { PromoCodeRow } from '@/lib/supabase';
 
 /**
  * Validate a promo code and return the promo data if valid

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -21,17 +21,16 @@ export {
   handlePreorderEmailWorkflow,
 } from './preorderEmails';
 
-// Email templates and display name helpers
+// Email templates and utilities
 export {
   generatePreorderConfirmationEmail,
-  getBoxTypeDisplayName,
-  getSportDisplayName,
-  getSportsDisplayNames,
-  getContentDisplayName,
-  getFlavorDisplayName,
-  getFlavorsDisplayNames,
-  getDietaryDisplayName,
-  getDietaryDisplayNames,
+  formatOptionsWithOther,
+} from './templates';
+
+// Email template types
+export type {
+  LabelMap,
+  EmailLabelMaps,
 } from './templates';
 
 // Types

--- a/lib/preorder/derived.ts
+++ b/lib/preorder/derived.ts
@@ -1,0 +1,274 @@
+/**
+ * Derived State Logic
+ * 
+ * Pure functions to compute derived state from user input.
+ * These functions are used by both client (hooks) and can be tested independently.
+ */
+
+import type {
+  BoxTypeId,
+  PreorderUserInput,
+  PreorderDerivedState,
+  PersonalizationStep,
+} from './types';
+
+// ============================================================================
+// Box Type Helpers
+// ============================================================================
+
+/**
+ * Check if a box type is premium (includes clothing)
+ */
+export function isPremiumBox(boxType: BoxTypeId | null): boolean {
+  if (!boxType) return false;
+  return boxType.includes('premium');
+}
+
+/**
+ * Check if a box type is a subscription (recurring)
+ */
+export function isSubscriptionBox(boxType: BoxTypeId | null): boolean {
+  if (!boxType) return false;
+  return boxType.startsWith('monthly-');
+}
+
+/**
+ * Get the display box type for UI selection
+ * Normalizes premium variants to 'monthly-premium'
+ */
+export function getDisplayBoxType(boxType: BoxTypeId | null): string | null {
+  if (boxType === 'monthly-premium-monthly' || boxType === 'monthly-premium-seasonal') {
+    return 'monthly-premium';
+  }
+  return boxType;
+}
+
+/**
+ * Get the premium frequency from a box type
+ */
+export function getPremiumFrequency(boxType: BoxTypeId | null): 'monthly' | 'seasonal' {
+  if (boxType === 'monthly-premium-seasonal') return 'seasonal';
+  return 'monthly';
+}
+
+/**
+ * Build the full box type ID from display type and frequency
+ */
+export function buildBoxTypeId(
+  displayType: string,
+  premiumFrequency: 'monthly' | 'seasonal'
+): BoxTypeId {
+  if (displayType === 'monthly-premium') {
+    return `monthly-premium-${premiumFrequency}` as BoxTypeId;
+  }
+  return displayType as BoxTypeId;
+}
+
+// ============================================================================
+// Personalization Steps
+// ============================================================================
+
+/**
+ * Determine which personalization steps are active based on box type and personalization choice
+ */
+export function getActivePersonalizationSteps(
+  wantsPersonalization: boolean | null,
+  isPremium: boolean
+): PersonalizationStep[] {
+  // If personalization choice not made yet, only show that step
+  if (wantsPersonalization === null) {
+    return ['personalization'];
+  }
+
+  if (isPremium) {
+    if (wantsPersonalization) {
+      return ['personalization', 'sport', 'colors', 'flavors', 'size', 'dietary', 'notes'];
+    } else {
+      // Premium without personalization still needs sizes for clothing
+      return ['personalization', 'size'];
+    }
+  } else {
+    // Standard box
+    if (wantsPersonalization) {
+      return ['personalization', 'sport', 'flavors', 'dietary', 'notes'];
+    } else {
+      // Standard without personalization - just the choice
+      return ['personalization'];
+    }
+  }
+}
+
+/**
+ * Calculate progress percentage for personalization steps
+ */
+export function calculatePersonalizationProgress(
+  currentStepIndex: number,
+  totalSteps: number
+): number {
+  if (totalSteps <= 1) return 100;
+  return ((currentStepIndex + 1) / totalSteps) * 100;
+}
+
+// ============================================================================
+// Requirements
+// ============================================================================
+
+/**
+ * Check if sizes are required for this box type
+ * Premium boxes always need sizes for clothing
+ */
+export function requiresSizes(boxType: BoxTypeId | null): boolean {
+  return isPremiumBox(boxType);
+}
+
+/**
+ * Check if color preferences are collected
+ * Only for premium boxes with personalization
+ */
+export function requiresColors(
+  boxType: BoxTypeId | null,
+  wantsPersonalization: boolean | null
+): boolean {
+  return isPremiumBox(boxType) && wantsPersonalization === true;
+}
+
+// ============================================================================
+// Full Derived State
+// ============================================================================
+
+/**
+ * Compute all derived state from user input
+ * This is the main function to use in components
+ */
+export function computeDerivedState(
+  input: PreorderUserInput,
+  currentPersonalizationStep: number = 0
+): PreorderDerivedState {
+  const isPremium = isPremiumBox(input.boxType);
+  const isSubscription = isSubscriptionBox(input.boxType);
+  const activeSteps = getActivePersonalizationSteps(input.wantsPersonalization, isPremium);
+  
+  return {
+    isPremium,
+    isSubscription,
+    requiresSizes: requiresSizes(input.boxType),
+    requiresColors: requiresColors(input.boxType, input.wantsPersonalization),
+    isStep1Valid: validateStep1(input),
+    isStep2Valid: validateStep2(input, isPremium),
+    isStep3Valid: validateStep3(input),
+    isComplete: validateComplete(input, isPremium),
+    activePersonalizationSteps: activeSteps,
+    personalizationProgress: calculatePersonalizationProgress(
+      currentPersonalizationStep,
+      activeSteps.length
+    ),
+  };
+}
+
+// ============================================================================
+// Step Validation (for derived state)
+// ============================================================================
+
+/**
+ * Validate Step 1: Box Selection
+ */
+function validateStep1(input: PreorderUserInput): boolean {
+  return input.boxType !== null;
+}
+
+/**
+ * Validate Step 2: Personalization
+ */
+function validateStep2(input: PreorderUserInput, isPremium: boolean): boolean {
+  // Must have made personalization choice
+  if (input.wantsPersonalization === null) {
+    return false;
+  }
+
+  // Premium boxes always need sizes
+  if (isPremium) {
+    if (!input.sizeUpper || !input.sizeLower) {
+      return false;
+    }
+  }
+
+  // If personalization is wanted, validate those fields
+  if (input.wantsPersonalization) {
+    // Sports required
+    if (input.sports.length === 0) {
+      return false;
+    }
+    // If "other" selected, must have text
+    if (input.sports.includes('other') && !input.sportOther.trim()) {
+      return false;
+    }
+
+    // Colors required for premium
+    if (isPremium && input.colors.length === 0) {
+      return false;
+    }
+
+    // Flavors required
+    if (input.flavors.length === 0) {
+      return false;
+    }
+    if (input.flavors.includes('other') && !input.flavorOther.trim()) {
+      return false;
+    }
+
+    // Dietary required
+    if (input.dietary.length === 0) {
+      return false;
+    }
+    if (input.dietary.includes('other') && !input.dietaryOther.trim()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Validate Step 3: Contact Info
+ */
+function validateStep3(input: PreorderUserInput): boolean {
+  if (!input.fullName.trim()) {
+    return false;
+  }
+  if (!input.email.trim()) {
+    return false;
+  }
+  // Basic email format check
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(input.email)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Validate complete preorder (all steps)
+ */
+function validateComplete(input: PreorderUserInput, isPremium: boolean): boolean {
+  return (
+    validateStep1(input) &&
+    validateStep2(input, isPremium) &&
+    validateStep3(input)
+  );
+}
+
+// ============================================================================
+// Utility: Sort with "other" at end
+// ============================================================================
+
+/**
+ * Sort an array of option IDs, keeping "other" at the end
+ * Used when saving to ensure consistent ordering
+ */
+export function sortWithOtherAtEnd(items: string[]): string[] {
+  return [...items].sort((a, b) => {
+    if (a === 'other') return 1;
+    if (b === 'other') return -1;
+    return 0;
+  });
+}

--- a/lib/preorder/format.ts
+++ b/lib/preorder/format.ts
@@ -1,0 +1,124 @@
+/**
+ * Formatting Utilities
+ * 
+ * Centralized formatting functions for prices and display values.
+ * Use these everywhere to ensure consistent formatting.
+ */
+
+// ============================================================================
+// Price Formatting
+// ============================================================================
+
+/**
+ * Format a price with 2 decimal places
+ * @param price - The price to format
+ * @returns Formatted price string (e.g., "24.90")
+ */
+export function formatPrice(price: number): string {
+  return price.toFixed(2);
+}
+
+/**
+ * Format a price with currency symbol (BGN)
+ * @param price - The price in BGN
+ * @returns Formatted price string (e.g., "24.90 лв")
+ */
+export function formatPriceBgn(price: number): string {
+  return `${formatPrice(price)} лв`;
+}
+
+/**
+ * Format a price with currency symbol (EUR)
+ * @param price - The price in EUR
+ * @returns Formatted price string (e.g., "24.90 €")
+ */
+export function formatPriceEur(price: number): string {
+  return `${formatPrice(price)} €`;
+}
+
+/**
+ * Format a price in both currencies
+ * @param priceEur - The price in EUR
+ * @param priceBgn - The price in BGN
+ * @returns Formatted price string (e.g., "48.70 лв / 24.90 €")
+ */
+export function formatPriceDual(priceEur: number, priceBgn: number): string {
+  return `${formatPrice(priceBgn)} лв / ${formatPrice(priceEur)} €`;
+}
+
+/**
+ * Format a discount percentage
+ * @param percent - The discount percentage
+ * @returns Formatted percentage string (e.g., "-10%")
+ */
+export function formatDiscount(percent: number): string {
+  return `-${percent}%`;
+}
+
+/**
+ * Format savings amount in both currencies
+ * @param amountEur - Savings in EUR
+ * @param amountBgn - Savings in BGN
+ * @returns Formatted savings string (e.g., "Спестяваш 4.87 лв / 2.49 €")
+ */
+export function formatSavings(amountEur: number, amountBgn: number): string {
+  return `Спестяваш ${formatPrice(amountBgn)} лв / ${formatPrice(amountEur)} €`;
+}
+
+// ============================================================================
+// Currency Conversion
+// ============================================================================
+
+/**
+ * Fixed EUR to BGN conversion rate
+ * This is the official fixed rate for Bulgaria
+ */
+export const EUR_TO_BGN_RATE = 1.9558;
+
+/**
+ * Convert EUR to BGN
+ * @param eur - Amount in EUR
+ * @returns Amount in BGN (rounded to 2 decimal places)
+ */
+export function eurToBgn(eur: number): number {
+  return Math.round(eur * EUR_TO_BGN_RATE * 100) / 100;
+}
+
+/**
+ * Convert BGN to EUR
+ * @param bgn - Amount in BGN
+ * @returns Amount in EUR (rounded to 2 decimal places)
+ */
+export function bgnToEur(bgn: number): number {
+  return Math.round((bgn / EUR_TO_BGN_RATE) * 100) / 100;
+}
+
+// ============================================================================
+// Discount Calculation
+// ============================================================================
+
+/**
+ * Calculate discount amount
+ * @param originalPrice - Original price
+ * @param discountPercent - Discount percentage (0-100)
+ * @returns Discount amount
+ */
+export function calculateDiscountAmount(
+  originalPrice: number,
+  discountPercent: number
+): number {
+  return Math.round((discountPercent / 100) * originalPrice * 100) / 100;
+}
+
+/**
+ * Calculate final price after discount
+ * @param originalPrice - Original price
+ * @param discountPercent - Discount percentage (0-100)
+ * @returns Final price after discount
+ */
+export function calculateFinalPrice(
+  originalPrice: number,
+  discountPercent: number
+): number {
+  return Math.round(originalPrice * (1 - discountPercent / 100) * 100) / 100;
+}

--- a/lib/preorder/index.ts
+++ b/lib/preorder/index.ts
@@ -1,0 +1,154 @@
+/**
+ * Preorder Domain Module
+ * 
+ * Centralized exports for all preorder-related types, utilities, and logic.
+ * Import from '@/lib/preorder' instead of individual files.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type {
+  // Box types
+  BoxTypeId,
+  BoxType,
+  PremiumFrequency,
+  
+  // Price information
+  PriceInfo,
+  PriceDisplayInfo,
+  PricesMap,
+  
+  // User input
+  PreorderUserInput,
+  
+  // Derived state
+  PersonalizationStep,
+  PreorderDerivedState,
+  
+  // Persistence
+  PreorderPersistData,
+  
+  // Catalog
+  CatalogOption,
+  ColorOption,
+  CatalogData,
+  
+  // Validation
+  ValidationError,
+  ValidationResult,
+  
+  // API responses
+  PricesApiResponse,
+  CatalogApiResponse,
+  PromoValidationResponse,
+  PreorderSubmitResponse,
+} from './types';
+
+// ============================================================================
+// Derived State Logic
+// ============================================================================
+
+export {
+  // Box type helpers
+  isPremiumBox,
+  isSubscriptionBox,
+  getDisplayBoxType,
+  getPremiumFrequency,
+  buildBoxTypeId,
+  
+  // Personalization steps
+  getActivePersonalizationSteps,
+  calculatePersonalizationProgress,
+  
+  // Requirements
+  requiresSizes,
+  requiresColors,
+  
+  // Full derived state
+  computeDerivedState,
+  
+  // Utilities
+  sortWithOtherAtEnd,
+} from './derived';
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+export {
+  // Regex patterns
+  EMAIL_REGEX,
+  PHONE_REGEX,
+  
+  // Validation functions
+  isValidEmail,
+  isValidPhone,
+  
+  // Error messages
+  getEmailError,
+  getPhoneError,
+  
+  // Step validation
+  validatePersonalizationStep,
+  
+  // Full validation
+  validatePreorderSubmission,
+  getFieldError,
+  hasFieldError,
+} from './validation';
+
+// ============================================================================
+// Formatting
+// ============================================================================
+
+export {
+  // Price formatting
+  formatPrice,
+  formatPriceBgn,
+  formatPriceEur,
+  formatPriceDual,
+  formatDiscount,
+  formatSavings,
+  
+  // Currency conversion
+  EUR_TO_BGN_RATE,
+  eurToBgn,
+  bgnToEur,
+  
+  // Discount calculation
+  calculateDiscountAmount,
+  calculateFinalPrice,
+} from './format';
+
+// ============================================================================
+// Labels (DEPRECATED - use lib/data/catalog.ts to fetch from database)
+// ============================================================================
+
+// NOTE: Label maps have been removed. Fetch labels from the database using:
+// - getBoxTypeNames() from lib/data/catalog.ts
+// - getOptionLabels('sports') from lib/data/catalog.ts
+// - getColorNames() from lib/data/catalog.ts
+// etc.
+//
+// For email templates, use formatOptionsWithOther from lib/email/templates.ts
+
+// ============================================================================
+// Transformation
+// ============================================================================
+
+export {
+  // Transform functions
+  transformToPersistedFormat,
+  transformToApiRequest,
+  
+  // Initial state
+  INITIAL_USER_INPUT,
+  
+  // Utilities
+  extractUserInput,
+  
+  // Types
+  type PreorderApiRequest,
+} from './transform';

--- a/lib/preorder/transform.ts
+++ b/lib/preorder/transform.ts
@@ -1,0 +1,208 @@
+/**
+ * Data Transformation
+ * 
+ * Functions to transform data between different formats:
+ * - User input (camelCase) → Persist format (snake_case)
+ * - API response → Domain types
+ */
+
+import type {
+  BoxTypeId,
+  PreorderUserInput,
+  PreorderPersistData,
+  PriceInfo,
+} from './types';
+import { sortWithOtherAtEnd } from './derived';
+
+// ============================================================================
+// User Input → Persist Format
+// ============================================================================
+
+/**
+ * Transform user input to database persist format
+ * This is the single place where camelCase → snake_case conversion happens
+ * 
+ * @param input - User input from form store
+ * @param priceInfo - Server-validated price information
+ * @returns Data ready for Supabase insertion
+ */
+export function transformToPersistedFormat(
+  input: PreorderUserInput,
+  priceInfo?: PriceInfo | null
+): PreorderPersistData {
+  // Ensure boxType is not null for persistence
+  if (!input.boxType) {
+    throw new Error('Box type is required for persistence');
+  }
+
+  return {
+    // Contact info
+    full_name: input.fullName.trim(),
+    email: input.email.trim().toLowerCase(),
+    phone: input.phone.trim() || null,
+
+    // Box selection
+    box_type: input.boxType,
+
+    // Personalization
+    wants_personalization: input.wantsPersonalization ?? false,
+    
+    // Preferences (sorted with "other" at end for consistency)
+    sports: input.sports.length > 0 ? sortWithOtherAtEnd(input.sports) : null,
+    sport_other: input.sportOther.trim() || null,
+    colors: input.colors.length > 0 ? input.colors : null,
+    flavors: input.flavors.length > 0 ? sortWithOtherAtEnd(input.flavors) : null,
+    flavor_other: input.flavorOther.trim() || null,
+    size_upper: input.sizeUpper || null,
+    size_lower: input.sizeLower || null,
+    dietary: input.dietary.length > 0 ? sortWithOtherAtEnd(input.dietary) : null,
+    dietary_other: input.dietaryOther.trim() || null,
+    additional_notes: input.additionalNotes.trim() || null,
+
+    // Pricing (from server-validated price info)
+    promo_code: priceInfo?.promoCode || input.promoCode || null,
+    discount_percent: priceInfo?.discountPercent || null,
+    original_price_eur: priceInfo?.originalPriceEur || null,
+    final_price_eur: priceInfo?.finalPriceEur || null,
+  };
+}
+
+// ============================================================================
+// API Request Format
+// ============================================================================
+
+/**
+ * Format for sending to /api/preorder
+ * This matches what the API route expects
+ */
+export interface PreorderApiRequest {
+  fullName: string;
+  email: string;
+  phone?: string;
+  boxType: BoxTypeId;
+  wantsPersonalization: boolean;
+  preferences?: {
+    sports?: string[];
+    sportOther?: string;
+    colors?: string[];
+    flavors?: string[];
+    flavorOther?: string;
+    dietary?: string[];
+    dietaryOther?: string;
+    additionalNotes?: string;
+  };
+  sizes?: {
+    upper?: string;
+    lower?: string;
+  };
+  promoCode?: string | null;
+}
+
+/**
+ * Transform user input to API request format
+ * 
+ * @param input - User input from form store
+ * @returns Data formatted for API submission
+ */
+export function transformToApiRequest(input: PreorderUserInput): PreorderApiRequest {
+  if (!input.boxType) {
+    throw new Error('Box type is required for submission');
+  }
+
+  const request: PreorderApiRequest = {
+    fullName: input.fullName.trim(),
+    email: input.email.trim().toLowerCase(),
+    boxType: input.boxType,
+    wantsPersonalization: input.wantsPersonalization ?? false,
+  };
+
+  // Optional phone
+  if (input.phone.trim()) {
+    request.phone = input.phone.trim();
+  }
+
+  // Preferences (only if personalization is wanted)
+  if (input.wantsPersonalization) {
+    request.preferences = {
+      sports: sortWithOtherAtEnd(input.sports),
+      sportOther: input.sportOther.trim() || undefined,
+      colors: input.colors.length > 0 ? input.colors : undefined,
+      flavors: sortWithOtherAtEnd(input.flavors),
+      flavorOther: input.flavorOther.trim() || undefined,
+      dietary: sortWithOtherAtEnd(input.dietary),
+      dietaryOther: input.dietaryOther.trim() || undefined,
+      additionalNotes: input.additionalNotes.trim() || undefined,
+    };
+  }
+
+  // Sizes (for premium boxes)
+  if (input.sizeUpper || input.sizeLower) {
+    request.sizes = {
+      upper: input.sizeUpper || undefined,
+      lower: input.sizeLower || undefined,
+    };
+  }
+
+  // Promo code
+  if (input.promoCode) {
+    request.promoCode = input.promoCode;
+  }
+
+  return request;
+}
+
+// ============================================================================
+// Form Store Initial State
+// ============================================================================
+
+/**
+ * Initial/empty state for user input
+ * Use this when resetting the form
+ */
+export const INITIAL_USER_INPUT: PreorderUserInput = {
+  boxType: null,
+  wantsPersonalization: null,
+  sports: [],
+  sportOther: '',
+  colors: [],
+  flavors: [],
+  flavorOther: '',
+  sizeUpper: '',
+  sizeLower: '',
+  dietary: [],
+  dietaryOther: '',
+  additionalNotes: '',
+  fullName: '',
+  email: '',
+  phone: '',
+  promoCode: null,
+};
+
+// ============================================================================
+// Utility: Extract user input from form store
+// ============================================================================
+
+/**
+ * Extract PreorderUserInput from a form store state
+ * Useful when the store has additional methods/properties
+ */
+export function extractUserInput(store: Record<string, unknown>): PreorderUserInput {
+  return {
+    boxType: (store.boxType as BoxTypeId | null) ?? null,
+    wantsPersonalization: (store.wantsPersonalization as boolean | null) ?? null,
+    sports: (store.sports as string[]) ?? [],
+    sportOther: (store.sportOther as string) ?? '',
+    colors: (store.colors as string[]) ?? [],
+    flavors: (store.flavors as string[]) ?? [],
+    flavorOther: (store.flavorOther as string) ?? '',
+    sizeUpper: (store.sizeUpper as string) ?? '',
+    sizeLower: (store.sizeLower as string) ?? '',
+    dietary: (store.dietary as string[]) ?? [],
+    dietaryOther: (store.dietaryOther as string) ?? '',
+    additionalNotes: (store.additionalNotes as string) ?? '',
+    fullName: (store.fullName as string) ?? '',
+    email: (store.email as string) ?? '',
+    phone: (store.phone as string) ?? '',
+    promoCode: (store.promoCode as string | null) ?? null,
+  };
+}

--- a/lib/preorder/types.ts
+++ b/lib/preorder/types.ts
@@ -1,0 +1,298 @@
+/**
+ * Canonical Preorder Domain Types
+ * 
+ * This is the single source of truth for all preorder-related types.
+ * All step pages, API routes, and services should import from here.
+ * 
+ * NOTE: BoxTypeId is re-exported from lib/supabase/types.ts where it's defined
+ * as BoxType to match the database enum. We alias it here for semantic clarity
+ * in the preorder domain (BoxTypeId = identifier, BoxType = full entity).
+ */
+
+// ============================================================================
+// Box Types
+// ============================================================================
+
+// Import the canonical BoxType from Supabase types (matches DB enum)
+// and re-export as BoxTypeId for semantic clarity in preorder domain
+import type { BoxType as SupabaseBoxType } from '@/lib/supabase/types';
+
+/**
+ * All valid box type identifiers
+ * This is an alias for the Supabase BoxType enum to maintain consistency
+ * with the database schema while providing semantic clarity in the preorder domain.
+ */
+export type BoxTypeId = SupabaseBoxType;
+
+/**
+ * Box type configuration from database
+ */
+export interface BoxType {
+  id: BoxTypeId;
+  name: string;
+  description: string | null;
+  priceEur: number;
+  isSubscription: boolean;
+  isPremium: boolean;
+  frequency: 'monthly' | 'seasonal' | null;
+  sortOrder: number;
+}
+
+/**
+ * Premium frequency options for monthly-premium box
+ */
+export type PremiumFrequency = 'monthly' | 'seasonal';
+
+// ============================================================================
+// Price Information (Derived - Server Calculated)
+// ============================================================================
+
+/**
+ * Complete price information for a box type
+ * This is the canonical PriceInfo type - use this everywhere
+ */
+export interface PriceInfo {
+  boxTypeId: string;
+  boxTypeName: string;
+  originalPriceEur: number;
+  originalPriceBgn: number;
+  discountPercent: number;
+  discountAmountEur: number;
+  discountAmountBgn: number;
+  finalPriceEur: number;
+  finalPriceBgn: number;
+  promoCode: string | null;
+}
+
+/**
+ * Simplified price info for display components
+ * Used by PriceDisplay component
+ */
+export interface PriceDisplayInfo {
+  originalPriceEur: number;
+  originalPriceBgn: number;
+  finalPriceEur: number;
+  finalPriceBgn: number;
+  discountPercent: number;
+  discountAmountEur: number;
+  discountAmountBgn: number;
+}
+
+// ============================================================================
+// User Input (Raw Form Data)
+// ============================================================================
+
+/**
+ * Raw user input collected across all steps
+ * This is what gets stored in the client-side form store
+ */
+export interface PreorderUserInput {
+  // Step 1: Box Selection
+  boxType: BoxTypeId | null;
+  
+  // Step 2: Personalization
+  wantsPersonalization: boolean | null;
+  sports: string[];
+  sportOther: string;
+  colors: string[];  // hex values
+  flavors: string[];
+  flavorOther: string;
+  sizeUpper: string;
+  sizeLower: string;
+  dietary: string[];
+  dietaryOther: string;
+  additionalNotes: string;
+  
+  // Step 3: Contact Info
+  fullName: string;
+  email: string;
+  phone: string;
+  
+  // Promo (from URL)
+  promoCode: string | null;
+}
+
+// ============================================================================
+// Derived State (Computed from UserInput)
+// ============================================================================
+
+/**
+ * Personalization sub-steps
+ */
+export type PersonalizationStep = 
+  | 'personalization' 
+  | 'sport' 
+  | 'colors' 
+  | 'flavors' 
+  | 'size' 
+  | 'dietary' 
+  | 'notes';
+
+/**
+ * Derived state computed from user input
+ * These values should never be stored - always computed
+ */
+export interface PreorderDerivedState {
+  // Box characteristics
+  isPremium: boolean;
+  isSubscription: boolean;
+  
+  // Personalization requirements
+  requiresSizes: boolean;
+  requiresColors: boolean;
+  
+  // Validation state
+  isStep1Valid: boolean;
+  isStep2Valid: boolean;
+  isStep3Valid: boolean;
+  isComplete: boolean;
+  
+  // Active personalization steps based on box type and personalization choice
+  activePersonalizationSteps: PersonalizationStep[];
+  
+  // Current step progress (for step 2)
+  personalizationProgress: number;
+}
+
+// ============================================================================
+// Persisted Data (What goes to Supabase)
+// ============================================================================
+
+/**
+ * Data format for Supabase insertion
+ * Uses snake_case to match database column names
+ */
+export interface PreorderPersistData {
+  // Contact
+  full_name: string;
+  email: string;
+  phone: string | null;
+  
+  // Box
+  box_type: BoxTypeId;
+  
+  // Personalization
+  wants_personalization: boolean;
+  sports: string[] | null;
+  sport_other: string | null;
+  colors: string[] | null;
+  flavors: string[] | null;
+  flavor_other: string | null;
+  size_upper: string | null;
+  size_lower: string | null;
+  dietary: string[] | null;
+  dietary_other: string | null;
+  additional_notes: string | null;
+  
+  // Pricing (server-validated)
+  promo_code: string | null;
+  discount_percent: number | null;
+  original_price_eur: number | null;
+  final_price_eur: number | null;
+}
+
+// ============================================================================
+// Catalog Options (for UI)
+// ============================================================================
+
+/**
+ * Generic option item for dropdowns/selections
+ */
+export interface CatalogOption {
+  id: string;
+  label: string;
+  value?: string | null;
+}
+
+/**
+ * Color option with hex value
+ */
+export interface ColorOption extends CatalogOption {
+  hex: string;
+}
+
+/**
+ * Complete catalog data for the preorder flow
+ */
+export interface CatalogData {
+  boxTypes: BoxType[];
+  options: {
+    sports: CatalogOption[];
+    colors: ColorOption[];
+    flavors: CatalogOption[];
+    dietary: CatalogOption[];
+    sizes: CatalogOption[];
+  };
+  labels: {
+    boxTypes: Record<string, string>;
+    sports: Record<string, string>;
+    colors: Record<string, string>;
+    flavors: Record<string, string>;
+    dietary: Record<string, string>;
+    sizes: Record<string, string>;
+  };
+}
+
+/**
+ * Prices map keyed by box type ID
+ */
+export type PricesMap = Record<string, PriceInfo>;
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Validation error for a specific field
+ */
+export interface ValidationError {
+  field: string;
+  message: string;
+  code: 'required' | 'invalid_format' | 'invalid_value' | 'too_short' | 'too_long';
+}
+
+/**
+ * Result of validating user input
+ */
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+// ============================================================================
+// API Response Types
+// ============================================================================
+
+/**
+ * Response from /api/catalog?type=prices
+ */
+export interface PricesApiResponse {
+  prices: PricesMap;
+}
+
+/**
+ * Response from /api/catalog?type=all
+ */
+export interface CatalogApiResponse extends CatalogData {
+  boxTypeNames: Record<string, string>;
+}
+
+/**
+ * Response from /api/promo/validate
+ */
+export interface PromoValidationResponse {
+  valid: boolean;
+  code?: string;
+  discountPercent?: number;
+  error?: string;
+}
+
+/**
+ * Response from /api/preorder POST
+ */
+export interface PreorderSubmitResponse {
+  success: boolean;
+  message?: string;
+  preorderId?: string;
+  error?: string;
+}

--- a/lib/preorder/validation.ts
+++ b/lib/preorder/validation.ts
@@ -1,0 +1,292 @@
+/**
+ * Validation Rules
+ * 
+ * Centralized validation logic for preorder data.
+ * Used by both client-side (for UI hints) and server-side (for enforcement).
+ */
+
+import type {
+  PreorderUserInput,
+  PersonalizationStep,
+  ValidationResult,
+  ValidationError,
+} from './types';
+import { isPremiumBox } from './derived';
+
+// ============================================================================
+// Email Validation
+// ============================================================================
+
+/**
+ * Email validation regex
+ * Matches standard email format: local@domain.tld
+ */
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Validate email format
+ */
+export function isValidEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email.trim());
+}
+
+/**
+ * Get email validation error message
+ */
+export function getEmailError(email: string): string | null {
+  if (!email.trim()) {
+    return 'Имейл адресът е задължителен';
+  }
+  if (!isValidEmail(email)) {
+    return 'Моля, въведете валиден имейл адрес';
+  }
+  return null;
+}
+
+// ============================================================================
+// Phone Validation
+// ============================================================================
+
+/**
+ * Phone validation regex
+ * Allows: digits, +, -, (, ), and spaces
+ */
+export const PHONE_REGEX = /^[0-9+\-() ]*$/;
+
+/**
+ * Validate phone format (optional field)
+ */
+export function isValidPhone(phone: string): boolean {
+  if (!phone.trim()) return true; // Phone is optional
+  return PHONE_REGEX.test(phone);
+}
+
+/**
+ * Get phone validation error message
+ */
+export function getPhoneError(phone: string): string | null {
+  if (phone && !isValidPhone(phone)) {
+    return 'Моля, въведете само цифри и символи за форматиране (+, -, (, ), интервал)';
+  }
+  return null;
+}
+
+// ============================================================================
+// Step-by-Step Validation
+// ============================================================================
+
+/**
+ * Validate a specific personalization step
+ * Returns true if the step is valid and user can proceed
+ */
+export function validatePersonalizationStep(
+  step: PersonalizationStep,
+  input: PreorderUserInput
+): boolean {
+  switch (step) {
+    case 'personalization':
+      return input.wantsPersonalization !== null;
+
+    case 'sport':
+      if (input.sports.length === 0) return false;
+      if (input.sports.includes('other') && !input.sportOther.trim()) return false;
+      return true;
+
+    case 'colors':
+      return input.colors.length > 0;
+
+    case 'flavors':
+      if (input.flavors.length === 0) return false;
+      if (input.flavors.includes('other') && !input.flavorOther.trim()) return false;
+      return true;
+
+    case 'size':
+      return Boolean(input.sizeUpper && input.sizeLower);
+
+    case 'dietary':
+      if (input.dietary.length === 0) return false;
+      if (input.dietary.includes('other') && !input.dietaryOther.trim()) return false;
+      return true;
+
+    case 'notes':
+      // Notes are always optional
+      return true;
+
+    default:
+      return true;
+  }
+}
+
+// ============================================================================
+// Full Preorder Validation (Server-side)
+// ============================================================================
+
+/**
+ * Validate complete preorder data for submission
+ * Returns detailed validation result with all errors
+ */
+export function validatePreorderSubmission(
+  input: PreorderUserInput
+): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  // Required: Box type
+  if (!input.boxType) {
+    errors.push({
+      field: 'boxType',
+      message: 'Моля, изберете тип кутия',
+      code: 'required',
+    });
+  }
+
+  // Required: Full name
+  if (!input.fullName.trim()) {
+    errors.push({
+      field: 'fullName',
+      message: 'Името е задължително',
+      code: 'required',
+    });
+  } else if (input.fullName.trim().length < 2) {
+    errors.push({
+      field: 'fullName',
+      message: 'Името трябва да е поне 2 символа',
+      code: 'too_short',
+    });
+  }
+
+  // Required: Email
+  if (!input.email.trim()) {
+    errors.push({
+      field: 'email',
+      message: 'Имейл адресът е задължителен',
+      code: 'required',
+    });
+  } else if (!isValidEmail(input.email)) {
+    errors.push({
+      field: 'email',
+      message: 'Невалиден имейл адрес',
+      code: 'invalid_format',
+    });
+  }
+
+  // Optional: Phone (but validate format if provided)
+  if (input.phone && !isValidPhone(input.phone)) {
+    errors.push({
+      field: 'phone',
+      message: 'Невалиден телефонен номер',
+      code: 'invalid_format',
+    });
+  }
+
+  // Required: Personalization choice
+  if (input.wantsPersonalization === null) {
+    errors.push({
+      field: 'wantsPersonalization',
+      message: 'Моля, изберете дали искате персонализация',
+      code: 'required',
+    });
+  }
+
+  const isPremium = isPremiumBox(input.boxType);
+
+  // Premium boxes require sizes
+  if (isPremium) {
+    if (!input.sizeUpper) {
+      errors.push({
+        field: 'sizeUpper',
+        message: 'Моля, изберете размер за горна част',
+        code: 'required',
+      });
+    }
+    if (!input.sizeLower) {
+      errors.push({
+        field: 'sizeLower',
+        message: 'Моля, изберете размер за долна част',
+        code: 'required',
+      });
+    }
+  }
+
+  // If personalization is wanted, validate those fields
+  if (input.wantsPersonalization === true) {
+    // Sports
+    if (input.sports.length === 0) {
+      errors.push({
+        field: 'sports',
+        message: 'Моля, изберете поне един спорт',
+        code: 'required',
+      });
+    }
+    if (input.sports.includes('other') && !input.sportOther.trim()) {
+      errors.push({
+        field: 'sportOther',
+        message: 'Моля, уточнете кой спорт',
+        code: 'required',
+      });
+    }
+
+    // Colors (premium only)
+    if (isPremium && input.colors.length === 0) {
+      errors.push({
+        field: 'colors',
+        message: 'Моля, изберете поне един цвят',
+        code: 'required',
+      });
+    }
+
+    // Flavors
+    if (input.flavors.length === 0) {
+      errors.push({
+        field: 'flavors',
+        message: 'Моля, изберете поне един вкус',
+        code: 'required',
+      });
+    }
+    if (input.flavors.includes('other') && !input.flavorOther.trim()) {
+      errors.push({
+        field: 'flavorOther',
+        message: 'Моля, уточнете кой вкус',
+        code: 'required',
+      });
+    }
+
+    // Dietary
+    if (input.dietary.length === 0) {
+      errors.push({
+        field: 'dietary',
+        message: 'Моля, изберете хранителни ограничения',
+        code: 'required',
+      });
+    }
+    if (input.dietary.includes('other') && !input.dietaryOther.trim()) {
+      errors.push({
+        field: 'dietaryOther',
+        message: 'Моля, уточнете какви ограничения',
+        code: 'required',
+      });
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Get first error for a specific field
+ */
+export function getFieldError(
+  result: ValidationResult,
+  field: string
+): string | null {
+  const error = result.errors.find((e) => e.field === field);
+  return error?.message ?? null;
+}
+
+/**
+ * Check if a specific field has errors
+ */
+export function hasFieldError(result: ValidationResult, field: string): boolean {
+  return result.errors.some((e) => e.field === field);
+}

--- a/lib/supabase/index.ts
+++ b/lib/supabase/index.ts
@@ -2,7 +2,16 @@
 export { supabase } from './client';
 
 // Types
-export type { Database, Preorder, PreorderInsert, BoxType } from './types';
+export type {
+  Database,
+  Preorder,
+  PreorderInsert,
+  BoxType,
+  BoxTypeRow,
+  OptionRow,
+  OptionSetId,
+  PromoCodeRow,
+} from './types';
 
 // Services
 export { 


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #41 

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
Finalizing the transition from hardcoded label maps to database-driven labels by removing the deprecated `lib/preorder/labels.ts` and centralizing all label fetching through Supabase via `lib/data/catalog.ts`. Email templates and step pages now rely exclusively on labels provided by the database. As part of the cleanup, obsolete fallbacks were removed and formatOptionsWithOther was relocated to the email templates where it’s actually used, enabling consistent labeling across the app and allowing label updates without code deployments.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [x] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
