### PR TITLE
[DEV] Refactor price formatting and add price info to email workflow

### DIFF
--- a/app/api/preorder/route.ts
+++ b/app/api/preorder/route.ts
@@ -100,9 +100,9 @@ export async function POST(request: Request) {
     }
 
     // Send confirmation email and add to contacts via Brevo
-    if (preorder) {
+    if (preorder && priceInfo) {
       try {
-        const { emailResult, contactResult } = await handlePreorderEmailWorkflow(preorder);
+        const { emailResult, contactResult } = await handlePreorderEmailWorkflow(preorder, priceInfo);
         
         if (!emailResult.success) {
           console.warn('Failed to send confirmation email:', emailResult.error);

--- a/app/step-4/page.tsx
+++ b/app/step-4/page.tsx
@@ -6,7 +6,8 @@ import { useFormStore, usePreorderInput } from '@/store/formStore';
 import Link from 'next/link';
 import type { PriceInfo } from '@/lib/preorder';
 import { 
-  formatPrice, 
+  formatPriceDual,
+  formatSavings,
   transformToApiRequest,
 } from '@/lib/preorder';
 
@@ -170,15 +171,15 @@ export default function Step4() {
                   {hasDiscount ? (
                     <div className="space-y-0.5 sm:space-y-1">
                       <div className="text-xs sm:text-sm text-gray-400 line-through">
-                        {formatPrice(priceInfo.originalPriceBgn)} лв / {formatPrice(priceInfo.originalPriceEur)} €
+                        {formatPriceDual(priceInfo.originalPriceEur, priceInfo.originalPriceBgn)}
                       </div>
                       <div className="text-xl sm:text-2xl font-bold text-[#FB7D00]">
-                        {formatPrice(priceInfo.finalPriceBgn)} лв / {formatPrice(priceInfo.finalPriceEur)} €
+                        {formatPriceDual(priceInfo.finalPriceEur, priceInfo.finalPriceBgn)}
                       </div>
                     </div>
                   ) : (
                     <div className="text-xl sm:text-2xl font-bold text-[#FB7D00]">
-                      {formatPrice(priceInfo.originalPriceBgn)} лв / {formatPrice(priceInfo.originalPriceEur)} €
+                      {formatPriceDual(priceInfo.originalPriceEur, priceInfo.originalPriceBgn)}
                     </div>
                   )}
                 </div>
@@ -197,7 +198,7 @@ export default function Step4() {
                   </span>
                 </div>
                 <div className="text-xs sm:text-sm text-gray-500 mt-1">
-                  Спестяваш {formatPrice(priceInfo.discountAmountBgn)} лв / {formatPrice(priceInfo.discountAmountEur)} €
+                  {formatSavings(priceInfo.discountAmountEur, priceInfo.discountAmountBgn)}
                 </div>
               </div>
             )}

--- a/components/PriceDisplay.tsx
+++ b/components/PriceDisplay.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { PriceDisplayInfo } from '@/lib/preorder';
-import { formatPrice } from '@/lib/preorder';
+import { formatPriceDual } from '@/lib/preorder';
 
 interface PriceDisplayProps {
   priceInfo: PriceDisplayInfo;
@@ -16,10 +16,10 @@ export default function PriceDisplay({ priceInfo }: PriceDisplayProps) {
     return (
       <div className="space-y-1">
         <div className="text-sm text-gray-400 line-through">
-          {formatPrice(priceInfo.originalPriceBgn)} лв / {formatPrice(priceInfo.originalPriceEur)} €
+          {formatPriceDual(priceInfo.originalPriceEur, priceInfo.originalPriceBgn)}
         </div>
         <div className="text-lg font-bold text-[#FB7D00]">
-          {formatPrice(priceInfo.finalPriceBgn)} лв / {formatPrice(priceInfo.finalPriceEur)} €
+          {formatPriceDual(priceInfo.finalPriceEur, priceInfo.finalPriceBgn)}
         </div>
         <div className="text-xs text-green-600 font-semibold">
           -{priceInfo.discountPercent}% отстъпка
@@ -30,7 +30,7 @@ export default function PriceDisplay({ priceInfo }: PriceDisplayProps) {
   
   return (
     <div className="text-lg font-bold text-[#023047]">
-      {formatPrice(priceInfo.originalPriceBgn)} лв / {formatPrice(priceInfo.originalPriceEur)} €
+      {formatPriceDual(priceInfo.originalPriceEur, priceInfo.originalPriceBgn)}
     </div>
   );
 }

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -8,8 +8,8 @@
 
 import type { PreorderEmailData } from './types';
 import {
-  formatPrice,
-  EUR_TO_BGN_RATE,
+  formatPriceDual,
+  formatSavings,
 } from '@/lib/preorder';
 
 // ============================================================================
@@ -102,26 +102,10 @@ function generateColorSwatchesHtml(colors: string[], colorLabels: LabelMap): str
 }
 
 /**
- * Format price for display (uses shared formatPrice)
- */
-function formatPriceForEmail(price: number): string {
-  return formatPrice(price);
-}
-
-/**
  * Generate promo code section HTML for email
  */
 function generatePromoCodeSection(data: PreorderEmailData): string {
-  if (!data.promoCode || !data.discountPercent || data.discountPercent <= 0) {
-    return '';
-  }
-
-  const originalPriceEur = data.originalPriceEur || 0;
-  const finalPriceEur = data.finalPriceEur || 0;
-  const discountAmountEur = originalPriceEur - finalPriceEur;
-  const originalPriceBgn = originalPriceEur * EUR_TO_BGN_RATE;
-  const finalPriceBgn = finalPriceEur * EUR_TO_BGN_RATE;
-  const discountAmountBgn = discountAmountEur * EUR_TO_BGN_RATE;
+  if (!data.hasPromoCode) return '';
 
   return `
     <div style="background-color: #d4edda; border: 1px solid #c3e6cb; padding: 15px; border-radius: 8px; margin: 15px 0;">
@@ -129,12 +113,12 @@ function generatePromoCodeSection(data: PreorderEmailData): string {
         ✅ Промо код ${data.promoCode} е приложен – ${data.discountPercent}% отстъпка
       </p>
       <p style="margin: 5px 0; color: #155724;">
-        <span style="text-decoration: line-through; color: #6c757d;">${formatPriceForEmail(originalPriceBgn)} лв / ${formatPriceForEmail(originalPriceEur)} €</span>
+        <span style="text-decoration: line-through; color: #6c757d;">${formatPriceDual(data.originalPriceEur ?? 0, data.originalPriceBgn ?? 0)}</span>
         &nbsp;→&nbsp;
-        <strong>${formatPriceForEmail(finalPriceBgn)} лв / ${formatPriceForEmail(finalPriceEur)} €</strong>
+        <strong>${formatPriceDual(data.finalPriceEur ?? 0, data.finalPriceBgn ?? 0)}</strong>
       </p>
       <p style="margin: 5px 0 0 0; color: #155724; font-size: 14px;">
-        Спестяваш ${formatPriceForEmail(discountAmountBgn)} лв / ${formatPriceForEmail(discountAmountEur)} €
+        ${formatSavings(data.discountAmountEur ?? 0, data.discountAmountBgn ?? 0)}
       </p>
     </div>
   `;
@@ -210,7 +194,7 @@ export function generatePreorderConfirmationEmail(
             <div style="background-color: #fff4ec; padding: 20px; border-radius: 8px; margin: 20px 0;">
               <h3 style="color: #363636; margin-top: 0;">📦 Детайли на поръчката</h3>
               <p style="margin: 5px 0;"><strong>Номер на поръчка:</strong> ${data.preorderId}</p>
-              <p style="margin: 5px 0;"><strong>Избрана кутия:</strong> ${data.boxTypeDisplay}</p>
+              <p style="margin: 5px 0;"><strong>Избрана кутия:</strong> ${data.boxTypeDisplay}${!data.hasPromoCode ? ` (${formatPriceDual(data.originalPriceEur ?? 0, data.originalPriceBgn ?? 0)})` : ''}</p>
               <p style="margin: 5px 0;"><strong>Персонализация:</strong> ${data.wantsPersonalization ? 'Да' : 'Не'}</p>
             </div>
             

--- a/lib/email/types.ts
+++ b/lib/email/types.ts
@@ -84,8 +84,14 @@ export interface PreorderEmailData {
   dietaryOther?: string;
   additionalNotes?: string;
   // Promo code fields
+  hasPromoCode: boolean;
   promoCode?: string | null;
   discountPercent?: number | null;
+  // Price fields
   originalPriceEur?: number | null;
   finalPriceEur?: number | null;
+  discountAmountEur?: number | null;
+  originalPriceBgn?: number | null;
+  finalPriceBgn?: number | null;
+  discountAmountBgn?: number | null;
 }

--- a/lib/preorder/format.ts
+++ b/lib/preorder/format.ts
@@ -40,10 +40,10 @@ export function formatPriceEur(price: number): string {
  * Format a price in both currencies
  * @param priceEur - The price in EUR
  * @param priceBgn - The price in BGN
- * @returns Formatted price string (e.g., "48.70 лв / 24.90 €")
+ * @returns Formatted price string (e.g., "24.90 € / 48.70 лв")
  */
 export function formatPriceDual(priceEur: number, priceBgn: number): string {
-  return `${formatPrice(priceBgn)} лв / ${formatPrice(priceEur)} €`;
+  return `${formatPrice(priceEur)} € / ${formatPrice(priceBgn)} лв`;
 }
 
 /**
@@ -59,10 +59,10 @@ export function formatDiscount(percent: number): string {
  * Format savings amount in both currencies
  * @param amountEur - Savings in EUR
  * @param amountBgn - Savings in BGN
- * @returns Formatted savings string (e.g., "Спестяваш 4.87 лв / 2.49 €")
+ * @returns Formatted savings string (e.g., "Спестяваш 2.49 € / 4.87 лв")
  */
 export function formatSavings(amountEur: number, amountBgn: number): string {
-  return `Спестяваш ${formatPrice(amountBgn)} лв / ${formatPrice(amountEur)} €`;
+  return `Спестяваш ${formatPrice(amountEur)} € / ${formatPrice(amountBgn)} лв`;
 }
 
 // ============================================================================


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #59 

---

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
This PR standardizes price presentation across the application by switching the display order to EUR / BGN and centralizing formatting logic in new formatPriceDual and formatSavings helpers. It also enhances the preorder email workflow by passing full PriceInfo data into email functions, enabling confirmation emails to include all calculated price fields, including BGN values and discount amounts. To simplify email template logic, a hasPromoCode flag was introduced, email types were extended with additional price fields, and minor TypeScript issues were resolved by safely handling nullable price values.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [x] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
