### PR TITLE
[DEV] Improve changeset detection to exclude README.md

### DIFF
--- a/.github/workflows/require-changeset.yaml
+++ b/.github/workflows/require-changeset.yaml
@@ -18,8 +18,8 @@ jobs:
             echo "🟡 skip-release label present, skipping changeset check"
             exit 0
           fi
-
-          if ls .changeset/*.md 1> /dev/null 2>&1; then
+          
+          if ls .changeset/*.md | grep -v README.md >/dev/null 2>&1; then
             echo "✅ Changeset found"
             exit 0
           fi


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #68 

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
The “require changeset” GitHub Actions workflow now ignores the README.md file.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [x] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [ ] Tested on Vercel preview (if applicable)
