### PR TITLE
[DEV] Update git config to use repo admin identity

### DIFF
--- a/.github/workflows/prod-tag.yaml
+++ b/.github/workflows/prod-tag.yaml
@@ -49,8 +49,8 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           TAG="v$VERSION"
 
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
+          git config user.name "misor-digital"
+          git config user.email "misor.digital@gmail.com"
           git add -A
           git commit -m "Update version: bump to $VERSION"
           git push


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #69 

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
The production tag GitHub Actions workflow can now create tags on behalf of the repo admin.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [x] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [ ] Tested on Vercel preview (if applicable)
