### PR TITLE
[STAGE] Add free delivery banner to preorder confirmation

### DIFF
--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -187,8 +187,15 @@ export function generatePreorderConfirmationEmail(
             </h2>
             
             <p style="color: #4a5568; font-size: 16px; line-height: 1.6;">
-              Твоята предварителна поръчка беше успешно регистрирана! Радваме се, че избра FitFlow.
+              Твоята предварителна поръчка беше успешно регистрирана! Благодарим ти, че избра FitFlow.
             </p>
+            
+            <!-- Free Delivery Banner -->
+            <div style="background-color: #e8f5e9; border: 2px solid #4caf50; padding: 15px 20px; border-radius: 8px; margin: 20px 0; text-align: center;">
+              <p style="margin: 0; color: #2e7d32; font-size: 18px; font-weight: bold;">
+                🚚 Безплатна доставка за твоята първа кутия!
+              </p>
+            </div>
             
             <!-- Order Details -->
             <div style="background-color: #fff4ec; padding: 20px; border-radius: 8px; margin: 20px 0;">


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #94 

---

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
This PR enhances the preorder confirmation email by adding a prominent green banner that highlights free delivery for the first box, making the offer immediately visible to recipients. It also updates the welcome text from “Радваме се” to “Благодарим ти” for a more appreciative tone and improves the overall visual hierarchy of the email to make key information clearer and easier to scan.

---

## Target branch checklist
- [ ] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
