### PR TITLE
[PROD] Switch form storage from localStorage to sessionStorage

### DIFF
--- a/store/formStore.ts
+++ b/store/formStore.ts
@@ -9,7 +9,7 @@
  */
 
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import type { BoxTypeId, PreorderUserInput } from '@/lib/preorder';
 import { INITIAL_USER_INPUT } from '@/lib/preorder';
 
@@ -85,9 +85,10 @@ export const useFormStore = create<FormStore>()(
       // Reset to initial state
       reset: () => set(INITIAL_USER_INPUT),
     }),
-    {
-      name: 'fitflow-form-storage',
-    }
+{
+  name: 'fitflow-form-storage',
+  storage: createJSONStorage(() => sessionStorage),
+}
   )
 );
 


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #98 

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
This PR updates the form persistence strategy by switching the persist middleware from localStorage to sessionStorage using the createJSONStorage utility. Form data is now cleared automatically when the browser session ends, improving user privacy and preventing stale or unintended data from persisting across sessions.
---

## Target branch checklist
- [ ] dev → feature work
- [ ] stage → release candidate
- [x] main → production only

---

## Release intent
- [x] This change affects production behavior
- [x] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [ ] Build passes
- [ ] Tested on Vercel preview (if applicable)
