### PR TITLE
[STAGE] Add PR title policy enforcement workflow

### DIFF
--- a/.github/workflows/pr-title-policy.yaml
+++ b/.github/workflows/pr-title-policy.yaml
@@ -1,0 +1,82 @@
+name: Enforce PR title policy
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  enforce-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve required prefix
+        id: rules
+        run: |
+          HEAD="${{ github.event.pull_request.head.ref }}"
+          BASE="${{ github.event.pull_request.base.ref }}"
+          TITLE="${{ github.event.pull_request.title }}"
+          LABELS=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
+
+          REQUIRED_PREFIX=""
+          REQUIRE_ANY_PREFIX="false"
+
+          # ----- HOTFIX override
+          if echo "$LABELS" | grep -qx "hotfix"; then
+            REQUIRED_PREFIX="[HOTFIX]"
+
+          # ----- Known base branches
+          elif [[ "$BASE" == "dev" ]]; then
+            REQUIRED_PREFIX="[DEV]"
+
+          elif [[ "$HEAD" == "dev" && "$BASE" == "stage" ]]; then
+            REQUIRED_PREFIX="[STAGE]"
+
+          elif [[ "$HEAD" == "stage" && "$BASE" == "main" ]]; then
+            REQUIRED_PREFIX="[PROD]"
+
+          # ----- Unknown base branch → must have *some* prefix
+          else
+            REQUIRE_ANY_PREFIX="true"
+          fi
+
+          echo "required_prefix=$REQUIRED_PREFIX" >> "$GITHUB_OUTPUT"
+          echo "require_any_prefix=$REQUIRE_ANY_PREFIX" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
+      - name: Enforce title prefix
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          REQUIRED="${{ steps.rules.outputs.required_prefix }}"
+          REQUIRE_ANY="${{ steps.rules.outputs.require_any_prefix }}"
+          TITLE="${{ steps.rules.outputs.title }}"
+
+          # ----- Exact prefix required
+          if [[ -n "$REQUIRED" ]]; then
+            if [[ "$TITLE" == "$REQUIRED"* ]]; then
+              echo "✅ PR title is valid"
+              exit 0
+            fi
+
+            echo "❌ PR title must start with $REQUIRED"
+            echo "Current title: $TITLE"
+            echo "Suggested title: $REQUIRED $TITLE"
+            exit 1
+          fi
+
+          # ----- Any prefix required ([SOMETHING])
+          if [[ "$REQUIRE_ANY" == "true" ]]; then
+            if [[ "$TITLE" =~ ^\[[A-Z0-9_-]+\]\  ]]; then
+              echo "✅ PR title has a custom prefix"
+              exit 0
+            fi
+
+            echo "❌ PR title must start with a prefix like [TEST], [SPIKE], [POC]"
+            echo "Current title: $TITLE"
+            exit 1
+          fi
+
+          exit 0


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #102 

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
This PR introduces a GitHub Actions workflow that enforces PR title conventions based on branch promotion rules and labels. It requires [STAGE] prefixes for dev → stage promotions and [PROD] prefixes for stage → main, with a [HOTFIX] override supported via label. The workflow blocks direct PRs to stage or main that aren’t valid promotions, while skipping enforcement for dev and feature branch PRs to keep everyday development frictionless.

---

## Target branch checklist
- [ ] dev → feature work
- [x] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [x] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [ ] Tested on Vercel preview (if applicable)
