### PR TITLE
[PROD] Add PR title policy enforcement workflow

### DIFF
--- a/.github/workflows/pr-title-policy.yaml
+++ b/.github/workflows/pr-title-policy.yaml
@@ -27,6 +27,10 @@ jobs:
           if echo "$LABELS" | grep -qx "hotfix"; then
             REQUIRED_PREFIX="[HOTFIX]"
 
+          # ----- RELEASE override
+          elif echo "$LABELS" | grep -qx "release"; then
+            REQUIRED_PREFIX="[RELEASE]"
+
           # ----- Known base branches
           elif [[ "$BASE" == "dev" ]]; then
             REQUIRED_PREFIX="[DEV]"


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #102 

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
This PR introduces a GitHub Actions workflow that enforces PR title conventions based on branch promotion rules and labels. It requires [STAGE] prefixes for dev → stage promotions and [PROD] prefixes for stage → main, with a [HOTFIX] override supported via label. The workflow blocks direct PRs to stage or main that aren’t valid promotions, while skipping enforcement for dev and feature branch PRs to keep everyday development frictionless.

---

## Target branch checklist
- [ ] dev → feature work
- [ ] stage → release candidate
- [x] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [x] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [ ] Tested on Vercel preview (if applicable)
