### PR TITLE
[DEV] Add hover and active interactions to all buttons

### DIFF
--- a/.changeset/huge-kids-joke.md
+++ b/.changeset/huge-kids-joke.md
@@ -1,0 +1,5 @@
+---
+"fitflow": patch
+---
+
+Add hover and active interactions to all buttons. Global `cursor: pointer` and `scale: 0.97` press feedback via `@layer base` in globals.css. Individual hover fixes for unstyled buttons in OrdersList, FAQ accordions, admin error pages, and dismiss buttons.

--- a/app/admin/error.tsx
+++ b/app/admin/error.tsx
@@ -22,7 +22,7 @@ export default function AdminError({
         </h2>
         <p className="text-gray-600 mb-6">{error.message || 'Неочаквана грешка'}</p>
         <div className="flex gap-4 justify-center">
-          <button onClick={reset} className="bg-[var(--color-brand-orange)] text-white px-4 py-2 rounded-lg text-sm font-semibold">
+          <button onClick={reset} className="bg-[var(--color-brand-orange)] text-white px-4 py-2 rounded-lg text-sm font-semibold hover:bg-[var(--color-brand-orange-dark)] transition-colors">
             Опитай отново
           </button>
           <Link href="/admin" className="bg-gray-200 text-gray-700 px-4 py-2 rounded-lg text-sm font-semibold">

--- a/app/globals.css
+++ b/app/globals.css
@@ -138,6 +138,19 @@ body {
   animation: success-pop 0.5s ease-out both;
 }
 
+/* Global button interactivity — pointer cursor + subtle press feedback */
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+
+  button:not(:disabled):active,
+  [role="button"]:not(:disabled):active {
+    scale: 0.97;
+  }
+}
+
 /* Reduced motion — disable transitions & animations for users who prefer it */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/components/account/OrdersList.tsx
+++ b/components/account/OrdersList.tsx
@@ -434,7 +434,7 @@ export function OrdersList({
         <button
           type="button"
           onClick={() => toggleExpand(order.id)}
-          className="w-full text-left"
+          className="w-full text-left hover:bg-gray-50 transition-colors rounded-xl"
         >
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
             {/* Left: order number + date */}

--- a/components/admin/CampaignHistoryTimeline.tsx
+++ b/components/admin/CampaignHistoryTimeline.tsx
@@ -104,7 +104,7 @@ export default function CampaignHistoryTimeline({ history }: CampaignHistoryTime
                   <button
                     type="button"
                     onClick={() => setExpandedId(isExpanded ? null : entry.id)}
-                    className="text-xs text-gray-400 hover:text-gray-600 mt-1"
+                    className="text-xs text-gray-400 hover:text-gray-600 mt-1 transition-colors"
                   >
                     {isExpanded ? 'Скрий детайли ▲' : 'Покажи детайли ▼'}
                   </button>

--- a/components/admin/CycleDetailView.tsx
+++ b/components/admin/CycleDetailView.tsx
@@ -360,7 +360,7 @@ export function CycleDetailView({
       {error && (
         <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
           {error}
-          <button onClick={() => setError(null)} className="ml-2 font-bold">
+          <button onClick={() => setError(null)} className="ml-2 font-bold hover:opacity-70 transition-opacity">
             ✕
           </button>
         </div>

--- a/components/admin/SubscriptionDetailView.tsx
+++ b/components/admin/SubscriptionDetailView.tsx
@@ -214,7 +214,7 @@ export function SubscriptionDetailView({
       {error && (
         <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
           {error}
-          <button onClick={() => setError(null)} className="ml-2 font-bold">✕</button>
+          <button onClick={() => setError(null)} className="ml-2 font-bold hover:opacity-70 transition-opacity">✕</button>
         </div>
       )}
       {success && (

--- a/components/box/MysteryBoxContent.tsx
+++ b/components/box/MysteryBoxContent.tsx
@@ -257,7 +257,7 @@ function FAQItem({ question, answer }: { question: string; answer: string }) {
     <div className="bg-gray-50 rounded-xl sm:rounded-2xl overflow-hidden shadow-sm border border-gray-100">
       <button
         onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between p-4 sm:p-5 md:p-6 text-left"
+        className="w-full flex items-center justify-between p-4 sm:p-5 md:p-6 text-left hover:bg-gray-50 transition-colors"
       >
         <span className="text-sm sm:text-base md:text-lg font-semibold text-[var(--color-brand-navy)] pr-4">
           {question}

--- a/components/box/RevealedBoxContent.tsx
+++ b/components/box/RevealedBoxContent.tsx
@@ -330,7 +330,7 @@ function FAQItem({ question, answer }: { question: string; answer: string }) {
     <div className="bg-gray-50 rounded-xl sm:rounded-2xl overflow-hidden shadow-sm border border-gray-100">
       <button
         onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between p-4 sm:p-5 md:p-6 text-left"
+        className="w-full flex items-center justify-between p-4 sm:p-5 md:p-6 text-left hover:bg-gray-50 transition-colors"
       >
         <span className="text-sm sm:text-base md:text-lg font-semibold text-[var(--color-brand-navy)] pr-4">
           {question}


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Issue #154 

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs
- [x] Chore

---

## Description
Buttons throughout the app now provide consistent visual feedback on hover and click. A global base style gives every non-disabled button a pointer cursor and a subtle scale-down on press, while seven previously unstyled buttons (order card toggles, FAQ accordions, error dismiss/reset buttons, and admin detail toggles) gained individual hover effects. The result is a more responsive, polished feel across all pages with no functional behavior changes.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
