### PR TITLE
[PROD] Refactor Meta Pixel events and add server-side CAPI for Purchase and Subscribe

### DIFF
--- a/.changeset/pixel-refactor.md
+++ b/.changeset/pixel-refactor.md
@@ -1,0 +1,15 @@
+---
+"fitflow": minor
+---
+
+Refactor Meta Pixel event hierarchy and add server-side CAPI for Purchase and Subscribe
+
+- Promote `Purchase` to primary conversion event on order completion; demote `Lead` to mid-funnel intent signal at Step 3
+- Fire `InitiateCheckout` when the order form mounts (Step 1)
+- Add server-side `Purchase` CAPI event in `/api/order` and custom `Subscribe` CAPI event in `/api/subscription` (Graph API v21.0)
+- Extract reusable `buildCapiUserData` helper for PII hashing across API routes
+- Deduplicate browser ↔ CAPI events via `capiEventId` passed through the order store to the thank-you page
+- Include `data_processing_options` on all CAPI events for GDPR compliance
+- Handle consent downgrade at runtime: revoke Meta Pixel consent, clear tracking cookies, and prompt page refresh
+- Skip analytics script rendering and CAPI calls in non-production environments
+- Update `meta-capi-setup.md` and `gdpr-cookie-consent.md` documentation

--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -17,7 +17,7 @@ import {
 import { validateAddress, addressInputToSnapshot } from '@/lib/order';
 import { isSubscriptionBox, EMAIL_REGEX, isValidPhone } from '@/lib/catalog';
 import { checkRateLimit } from '@/lib/utils/rateLimit';
-import { trackLeadCapi, hashForMeta, generateEventId } from '@/lib/analytics';
+import { trackPurchaseCapi, buildCapiUserData, generateEventId } from '@/lib/analytics';
 import type { OrderInsert, ShippingAddressSnapshot, Preorder, BoxType, OrderType } from '@/lib/supabase/types';
 import type { AddressInput } from '@/lib/order';
 import { sendTransactionalEmail, syncOrderToContact } from '@/lib/email/brevo';
@@ -747,43 +747,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       emailSent = false;
     }
 
-    // 8d. Server-side Meta CAPI event tracking
+    // 8d. Server-side Meta CAPI event tracking (Purchase = primary conversion)
+    let capiEventId: string | undefined;
     try {
-      const clientIp =
-        headersList.get('x-forwarded-for')?.split(',')[0] ||
-        headersList.get('x-real-ip') ||
-        '';
-      const userAgent = headersList.get('user-agent') || '';
-      const referer = headersList.get('referer') || '';
+      const { userData, referer } = await buildCapiUserData({
+        headersObj: headersList,
+        email,
+        phone: phone || undefined,
+        fullName,
+        fbc: (data as Record<string, unknown>).fbc as string | undefined,
+        fbp: (data as Record<string, unknown>).fbp as string | undefined,
+      });
 
-      // Parse name into first and last name
-      const nameParts = fullName.trim().split(' ');
-      const firstName = nameParts[0] || '';
-      const lastName = nameParts.slice(1).join(' ') || '';
-
-      // Hash user data for Meta CAPI
-      const [hashedEmail, hashedPhone, hashedFirstName, hashedLastName] = await Promise.all([
-        hashForMeta(email),
-        phone ? hashForMeta(phone) : Promise.resolve(undefined),
-        firstName ? hashForMeta(firstName) : Promise.resolve(undefined),
-        lastName ? hashForMeta(lastName) : Promise.resolve(undefined),
-      ]);
-
-      const capiResult = await trackLeadCapi({
-        eventId: generateEventId(),
+      capiEventId = generateEventId();
+      const capiResult = await trackPurchaseCapi({
+        eventId: capiEventId,
         sourceUrl:
           referer ||
           `${process.env.NEXT_PUBLIC_SITE_URL || 'https://fitflow.bg'}/thank-you/order`,
-        userData: {
-          em: hashedEmail,
-          ph: hashedPhone,
-          fn: hashedFirstName,
-          ln: hashedLastName,
-          client_ip_address: clientIp,
-          client_user_agent: userAgent,
-          fbc: (data as Record<string, unknown>).fbc as string | undefined,
-          fbp: (data as Record<string, unknown>).fbp as string | undefined,
-        },
+        userData,
         customData: {
           currency: 'EUR',
           value: priceInfo.finalPriceEur,
@@ -810,6 +792,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         orderId: order.id,
         orderNumber: order.order_number,
         finalPriceEur: priceInfo.finalPriceEur ?? null,
+        capiEventId: capiEventId ?? null,
         _meta: {
           emailSent,
           conversionCompleted,

--- a/app/api/subscription/route.ts
+++ b/app/api/subscription/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { headers } from 'next/headers';
 import { verifySession } from '@/lib/auth';
 import {
   getSubscriptionsByUser,
@@ -15,6 +16,7 @@ import {
 } from '@/lib/data';
 import { validatePreferenceUpdate, findNextCycleForSubscription } from '@/lib/subscription';
 import { checkRateLimit } from '@/lib/utils/rateLimit';
+import { trackSubscribeCapi, buildCapiUserData, generateEventId } from '@/lib/analytics';
 import { determineFirstCycle } from '@/lib/delivery/assignment';
 import { generateSingleOrderForSubscription } from '@/lib/delivery/generate';
 import { sendSubscriptionCreatedEmail } from '@/lib/subscription/notifications';
@@ -491,6 +493,43 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       }
     }
 
+    // 9a-bis. Server-side Meta CAPI event tracking (Subscribe custom event)
+    let subscribeCapiEventId: string | undefined;
+    try {
+      const headersList = await headers();
+      const customerEmail = sourceOrder?.customer_email ?? session?.email ?? '';
+      const customerFullName = sourceOrder?.customer_full_name ?? '';
+
+      const { userData, referer } = await buildCapiUserData({
+        headersObj: headersList,
+        email: customerEmail || undefined,
+        fullName: customerFullName || undefined,
+        fbc: (data as Record<string, unknown>).fbc as string | undefined,
+        fbp: (data as Record<string, unknown>).fbp as string | undefined,
+      });
+
+      subscribeCapiEventId = generateEventId();
+      const capiResult = await trackSubscribeCapi({
+        eventId: subscribeCapiEventId,
+        sourceUrl:
+          referer ||
+          `${process.env.NEXT_PUBLIC_SITE_URL || 'https://fitflow.bg'}/subscription`,
+        userData,
+        customData: {
+          currency: 'EUR',
+          value: priceInfo.finalPriceEur,
+          content_name: effectiveBoxType,
+          content_category: 'subscription',
+        },
+      });
+
+      if (!capiResult.success) {
+        console.warn('Meta CAPI Subscribe event failed:', capiResult.error);
+      }
+    } catch (capiError) {
+      console.error('Error sending Meta CAPI Subscribe event:', capiError);
+    }
+
     // ------------------------------------------------------------------
     // Step 9b: If subscribing into a cycle that's already processing,
     //          generate their order now (late addition)
@@ -589,6 +628,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const responsePayload: Record<string, unknown> = {
       success: true,
       subscription,
+      capiEventId: subscribeCapiEventId ?? null,
     };
 
     if (accountLoginUrl) {

--- a/app/order/thank-you/page.tsx
+++ b/app/order/thank-you/page.tsx
@@ -5,10 +5,11 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useOrderStore } from '@/store/orderStore';
 import {
-  trackLead,
+  trackPurchase,
   trackGenerateLead,
   setUserProperties,
 } from '@/lib/analytics';
+import { trackSubscriptionCreated } from '@/lib/analytics/subscription';
 
 interface LastOrderInfo {
   orderNumber: string | null;
@@ -19,6 +20,7 @@ interface LastOrderInfo {
   isSubscription?: boolean;
   boxType?: string | null;
   finalPriceEur?: number | null;
+  capiEventId?: string | null;
 }
 
 export default function OrderThankYou() {
@@ -52,8 +54,24 @@ export default function OrderThankYou() {
   useEffect(() => {
     if (!orderInfo || hasTracked.current) return;
 
-    // Meta Pixel - Lead event (purchase tracking can be added when payments are live)
-    trackLead();
+    if (orderInfo.isSubscription) {
+      // Meta Pixel - Subscribe custom event (client-side, deduplicated with CAPI)
+      trackSubscriptionCreated(
+        orderInfo.boxType ?? 'unknown',
+        'monthly', // default frequency
+        orderInfo.finalPriceEur ?? 0,
+        orderInfo.capiEventId ?? undefined,
+      );
+    } else {
+      // Meta Pixel - Purchase event (primary conversion, deduplicated with CAPI via event_id)
+      trackPurchase({
+        value: orderInfo.finalPriceEur ?? 0,
+        currency: 'EUR',
+        contentName: orderInfo.boxType ?? undefined,
+        orderId: orderInfo.orderId ?? undefined,
+        eventId: orderInfo.capiEventId ?? undefined,
+      });
+    }
 
     // GA4 - generate_lead event
     trackGenerateLead({

--- a/components/ConditionalScripts.tsx
+++ b/components/ConditionalScripts.tsx
@@ -30,6 +30,9 @@ export default function ConditionalScripts({
 }: ConditionalScriptsProps) {
   const { isLoaded, preferences } = useConsentStore();
 
+  // Only load analytics/marketing scripts in production
+  if (process.env.NODE_ENV !== 'production') return null;
+
   // Don't render anything until consent state is loaded
   if (!isLoaded) return null;
 

--- a/components/CookieConsentBanner.tsx
+++ b/components/CookieConsentBanner.tsx
@@ -15,6 +15,7 @@ export default function CookieConsentBanner() {
     showBanner,
     showPreferences,
     preferences,
+    requiresRefresh,
     initialize,
     acceptAll,
     rejectNonEssential,
@@ -49,8 +50,8 @@ export default function CookieConsentBanner() {
   // Don't render until loaded (prevents hydration mismatch)
   if (!isLoaded) return null;
 
-  // Don't show if banner is hidden and preferences modal is closed
-  if (!showBanner && !showPreferences) return null;
+  // Don't show if banner is hidden, preferences modal is closed, and no refresh needed
+  if (!showBanner && !showPreferences && !requiresRefresh) return null;
 
   const handleSavePreferences = () => {
     savePreferences({
@@ -212,6 +213,21 @@ export default function CookieConsentBanner() {
               </p>
             </div>
           </div>
+        </div>
+      )}
+
+      {/* Refresh prompt after consent downgrade */}
+      {requiresRefresh && !showBanner && !showPreferences && (
+        <div className="fixed bottom-4 right-4 z-50 max-w-sm bg-white rounded-xl shadow-lg border border-gray-200 p-4">
+          <p className="text-sm text-gray-700 mb-3">
+            Настройките са запазени. Моля, презаредете страницата за пълно прилагане.
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            className="w-full px-4 py-2 text-sm font-medium text-white bg-[#023047] hover:bg-[#034a6e] rounded-lg transition-colors"
+          >
+            Презареди страницата
+          </button>
         </div>
       )}
     </>

--- a/components/order/OrderFlow.tsx
+++ b/components/order/OrderFlow.tsx
@@ -253,6 +253,7 @@ export default function OrderFlow({
             isSubscription: true,
             boxType: currentInput.boxType,
             finalPriceEur: sub.current_price_eur ?? null,
+            capiEventId: responseData.capiEventId ?? null,
           }),
         );
       } else {
@@ -281,6 +282,8 @@ export default function OrderFlow({
             isGuest: currentInput.isGuest,
             isSubscription: false,
             finalPriceEur: responseData.finalPriceEur ?? null,
+            boxType: currentInput.boxType,
+            capiEventId: responseData.capiEventId ?? null,
           }),
         );
       }

--- a/components/order/OrderStepBox.tsx
+++ b/components/order/OrderStepBox.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useOrderStore } from '@/store/orderStore';
-import { trackFunnelStep, trackBoxSelection } from '@/lib/analytics';
+import { trackFunnelStep, trackBoxSelection, trackInitiateCheckout } from '@/lib/analytics';
 import PriceDisplay from '@/components/PriceDisplay';
 import type { PricesMap, BoxTypeId, PriceInfo } from '@/lib/catalog';
 import { getDisplayBoxType, getPremiumFrequency, buildBoxTypeId } from '@/lib/catalog';
@@ -18,10 +18,11 @@ export default function OrderStepBox({ prices, boxTypeNames, onNext }: OrderStep
   const { boxType, setBoxType, setFrequency, promoCode } = useOrderStore();
   const hasTrackedStep = useRef(false);
 
-  // Track funnel step on mount
+  // Track funnel step + InitiateCheckout on mount
   useEffect(() => {
     if (!hasTrackedStep.current) {
       trackFunnelStep('box_selection', 1);
+      trackInitiateCheckout();
       hasTrackedStep.current = true;
     }
   }, []);

--- a/components/order/OrderStepDetails.tsx
+++ b/components/order/OrderStepDetails.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useOrderStore } from '@/store/orderStore';
 import { useAuthStore } from '@/store/authStore';
-import { trackFunnelStep, trackFormInteraction } from '@/lib/analytics';
+import { trackFunnelStep, trackFormInteraction, trackLead } from '@/lib/analytics';
 import { isValidEmail, isValidPhone, getEmailError, getPhoneError } from '@/lib/catalog';
 import { isSubscriptionBox } from '@/lib/catalog';
 import { getAddressFieldError, validateAddress, validateSpeedyOffice } from '@/lib/order';
@@ -41,6 +41,7 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
   const onBehalfOfUserId = useOrderStore((s) => s.onBehalfOfUserId);
   const conversionToken = useOrderStore((s) => s.conversionToken);
   const hasTrackedStep = useRef(false);
+  const hasTrackedLead = useRef(false);
 
   // Track funnel step on mount
   useEffect(() => {
@@ -265,6 +266,15 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
       return [fullName.trim(), email.trim(), phone.trim()];
     };
 
+    // Fire Lead event once when user completes Step 3 (mid-funnel intent signal)
+    const advanceToNext = () => {
+      if (!hasTrackedLead.current) {
+        trackLead();
+        hasTrackedLead.current = true;
+      }
+      onNext();
+    };
+
     // --- SPEEDY OFFICE DELIVERY ---
     if (deliveryMethod === 'speedy_office') {
       // Validate office selection + required fields (fullName, phone)
@@ -304,7 +314,7 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
         fullName: address.fullName,
         phone: address.phone,
       });
-      onNext();
+      advanceToNext();
       return;
     }
 
@@ -321,7 +331,7 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
       store.setDeliveryMethod('address');
       store.setSpeedyOffice(null);
       store.setAddress(address);
-      onNext();
+      advanceToNext();
     } else if (isAdminGuestConversion) {
       // Admin converting without account → guest order with customer's info
       const addressValid = validateAddressForm();
@@ -333,7 +343,7 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
       store.setDeliveryMethod('address');
       store.setSpeedyOffice(null);
       store.setAddress(address);
-      onNext();
+      advanceToNext();
     } else if (isAuthenticated) {
       // Branch C: Authenticated
       if (selectedAddressId && !showNewAddressForm) {
@@ -342,7 +352,7 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
         store.setSelectedAddressId(selectedAddressId);
         store.setDeliveryMethod('address');
         store.setSpeedyOffice(null);
-        onNext();
+        advanceToNext();
       } else {
         const addressValid = validateAddressForm();
         if (!addressValid) return;
@@ -353,7 +363,7 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
         store.setDeliveryMethod('address');
         store.setSpeedyOffice(null);
         store.setAddress(address);
-        onNext();
+        advanceToNext();
       }
     }
   };

--- a/docs/gdpr-cookie-consent.md
+++ b/docs/gdpr-cookie-consent.md
@@ -121,10 +121,12 @@ The consent banner provides three actions:
    - Pros: Simpler, no server-side handling needed
    - Cons: Not shared across subdomains
 
-2. **Script Unloading**
-   - Once scripts are loaded, they cannot be unloaded without page refresh
-   - If user revokes consent, scripts won't load on next visit
-   - Consider adding a page refresh prompt on consent change
+2. **Script Unloading & Consent Revocation**
+   - Once scripts are loaded, they cannot be fully removed without page refresh
+   - On consent revocation: `fbq('consent', 'revoke')` stops Meta Pixel immediately
+   - Tracking cookies (`_fbp`, `_fbc`, `_ga`, `_gid`) are proactively cleared
+   - A refresh prompt is shown to the user for full script cleanup
+   - On next page load, revoked scripts won't load at all
 
 3. **Third-Party Cookies**
    - We control when scripts load, but not what cookies they set

--- a/docs/meta-capi-setup.md
+++ b/docs/meta-capi-setup.md
@@ -37,7 +37,10 @@ Currently, the following events are sent via CAPI:
 
 | Event | Trigger | Location |
 |-------|---------|----------|
-| `Lead` | Successful order submission | `/api/order` |
+| `Purchase` | Successful order creation | `/api/order` |
+| `Subscribe` | Successful subscription creation | `/api/subscription` |
+
+The `data_processing_options` field is included in all CAPI events (empty array = no restrictions, since events only fire when user has given marketing consent).
 
 ## Event Deduplication
 
@@ -112,7 +115,8 @@ const response = await fetch(
 
 1. Submit a test order
 2. Check Events Manager > Test Events
-3. Verify the Lead event appears with correct data
+3. Verify the Purchase event appears with correct data
+4. Create a test subscription and verify Subscribe custom event appears
 
 ## Troubleshooting
 
@@ -157,6 +161,9 @@ Improve match rate by including more user data:
 
 ## Files
 
-- `lib/analytics/metaCapi.ts` - CAPI utility functions
+- `lib/analytics/metaCapi.ts` - CAPI utility functions (v21.0)
+- `lib/analytics/metaPixel.ts` - Browser pixel event functions
+- `lib/analytics/subscription.ts` - Subscription analytics (client-side)
 - `lib/analytics/index.ts` - Exports
-- `app/api/order/route.ts` - Lead event integration
+- `app/api/order/route.ts` - Purchase event integration
+- `app/api/subscription/route.ts` - Subscribe event integration

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -4,6 +4,7 @@ export {
   trackViewContent,
   trackInitiateCheckout,
   trackLead,
+  trackPurchase,
 } from './metaPixel';
 
 // Meta CAPI exports (server-side)
@@ -13,10 +14,13 @@ export {
   sendMetaEvents,
   hashForMeta,
   generateEventId,
+  buildCapiUserData,
   // Helper functions
   trackLeadCapi,
   trackViewContentCapi,
   trackInitiateCheckoutCapi,
+  trackPurchaseCapi,
+  trackSubscribeCapi,
   // Types
   type MetaEventName,
   type MetaUserData,

--- a/lib/analytics/metaCapi.ts
+++ b/lib/analytics/metaCapi.ts
@@ -15,14 +15,15 @@
  */
 
 // Meta CAPI endpoint
-const META_CAPI_ENDPOINT = 'https://graph.facebook.com/v18.0';
+const META_CAPI_ENDPOINT = 'https://graph.facebook.com/v21.0';
 
 // Event names matching browser pixel events
 export type MetaEventName = 
   | 'PageView'
   | 'ViewContent'
   | 'InitiateCheckout'
-  | 'Lead';
+  | 'Lead'
+  | 'Purchase';
 
 // User data for matching (hashed on client, sent as-is here)
 export interface MetaUserData {
@@ -55,11 +56,12 @@ export interface MetaCustomData {
 
 // Server event structure
 export interface MetaServerEvent {
-  event_name: MetaEventName;
+  event_name: MetaEventName | string; // string allows custom events like 'Subscribe'
   event_time: number;
   event_id: string;           // For deduplication with browser pixel
   event_source_url: string;
   action_source: 'website';
+  data_processing_options: string[]; // GDPR: empty array = no restrictions (consent gated)
   user_data: MetaUserData;
   custom_data?: MetaCustomData;
 }
@@ -73,6 +75,52 @@ interface MetaApiResponse {
     message: string;
     type: string;
     code: number;
+  };
+}
+
+/**
+ * Build hashed MetaUserData from request headers and customer info.
+ * Extracts IP, user-agent, referer and hashes PII fields.
+ * Reusable across any API route that sends CAPI events.
+ */
+export async function buildCapiUserData(opts: {
+  headersObj: Headers;
+  email?: string;
+  phone?: string;
+  fullName?: string;
+  fbc?: string;
+  fbp?: string;
+}): Promise<{ userData: MetaUserData; referer: string }> {
+  const clientIp =
+    opts.headersObj.get('x-forwarded-for')?.split(',')[0] ||
+    opts.headersObj.get('x-real-ip') ||
+    '';
+  const userAgent = opts.headersObj.get('user-agent') || '';
+  const referer = opts.headersObj.get('referer') || '';
+
+  const nameParts = (opts.fullName ?? '').trim().split(' ');
+  const firstName = nameParts[0] || '';
+  const lastName = nameParts.slice(1).join(' ') || '';
+
+  const [hashedEmail, hashedPhone, hashedFirstName, hashedLastName] = await Promise.all([
+    opts.email ? hashForMeta(opts.email) : Promise.resolve(undefined),
+    opts.phone ? hashForMeta(opts.phone) : Promise.resolve(undefined),
+    firstName ? hashForMeta(firstName) : Promise.resolve(undefined),
+    lastName ? hashForMeta(lastName) : Promise.resolve(undefined),
+  ]);
+
+  return {
+    userData: {
+      em: hashedEmail,
+      ph: hashedPhone,
+      fn: hashedFirstName,
+      ln: hashedLastName,
+      client_ip_address: clientIp,
+      client_user_agent: userAgent,
+      fbc: opts.fbc,
+      fbp: opts.fbp,
+    },
+    referer,
   };
 }
 
@@ -100,6 +148,10 @@ export function generateEventId(): string {
  * Send event to Meta Conversions API
  */
 export async function sendMetaEvent(event: MetaServerEvent): Promise<{ success: boolean; error?: string }> {
+  if (process.env.NODE_ENV !== 'production') {
+    return { success: true }; // Silently skip in non-production
+  }
+
   const pixelId = process.env.META_PIXEL_ID;
   const accessToken = process.env.META_CAPI_ACCESS_TOKEN;
 
@@ -140,6 +192,10 @@ export async function sendMetaEvent(event: MetaServerEvent): Promise<{ success: 
  * Send multiple events to Meta Conversions API (batch)
  */
 export async function sendMetaEvents(events: MetaServerEvent[]): Promise<{ success: boolean; error?: string }> {
+  if (process.env.NODE_ENV !== 'production') {
+    return { success: true }; // Silently skip in non-production
+  }
+
   const pixelId = process.env.META_PIXEL_ID;
   const accessToken = process.env.META_CAPI_ACCESS_TOKEN;
 
@@ -200,6 +256,7 @@ export async function trackLeadCapi(params: {
     event_id: params.eventId,
     event_source_url: params.sourceUrl,
     action_source: 'website',
+    data_processing_options: [],
     user_data: params.userData,
     custom_data: params.customData,
   };
@@ -222,6 +279,7 @@ export async function trackViewContentCapi(params: {
     event_id: params.eventId,
     event_source_url: params.sourceUrl,
     action_source: 'website',
+    data_processing_options: [],
     user_data: params.userData,
     custom_data: params.customData,
   };
@@ -244,6 +302,55 @@ export async function trackInitiateCheckoutCapi(params: {
     event_id: params.eventId,
     event_source_url: params.sourceUrl,
     action_source: 'website',
+    data_processing_options: [],
+    user_data: params.userData,
+    custom_data: params.customData,
+  };
+
+  return sendMetaEvent(event);
+}
+
+/**
+ * Track Purchase event via CAPI (primary conversion)
+ * Call this from your API route after successful order creation
+ */
+export async function trackPurchaseCapi(params: {
+  eventId: string;
+  sourceUrl: string;
+  userData: MetaUserData;
+  customData?: MetaCustomData;
+}): Promise<{ success: boolean; error?: string }> {
+  const event: MetaServerEvent = {
+    event_name: 'Purchase',
+    event_time: Math.floor(Date.now() / 1000),
+    event_id: params.eventId,
+    event_source_url: params.sourceUrl,
+    action_source: 'website',
+    data_processing_options: [],
+    user_data: params.userData,
+    custom_data: params.customData,
+  };
+
+  return sendMetaEvent(event);
+}
+
+/**
+ * Track Subscribe custom event via CAPI
+ * Call this from your subscription API route after successful creation
+ */
+export async function trackSubscribeCapi(params: {
+  eventId: string;
+  sourceUrl: string;
+  userData: MetaUserData;
+  customData?: MetaCustomData;
+}): Promise<{ success: boolean; error?: string }> {
+  const event: MetaServerEvent = {
+    event_name: 'Subscribe',
+    event_time: Math.floor(Date.now() / 1000),
+    event_id: params.eventId,
+    event_source_url: params.sourceUrl,
+    action_source: 'website',
+    data_processing_options: [],
     user_data: params.userData,
     custom_data: params.customData,
   };

--- a/lib/analytics/metaPixel.ts
+++ b/lib/analytics/metaPixel.ts
@@ -7,17 +7,19 @@
  * Standard events implemented:
  * - PageView: Automatically fired by the pixel on every page load
  * - ViewContent: Fired on landing page to indicate core offer/content
- * - InitiateCheckout: Fired when user starts interacting with the form
- * - Lead: Fired on successful form submission (primary conversion)
+ * - InitiateCheckout: Fired when user enters the order form
+ * - Lead: Fired when user completes contact info (mid-funnel intent signal)
+ * - Purchase: Fired on successful order completion (primary conversion)
  */
 
 // Extend Window interface to include fbq
 declare global {
   interface Window {
     fbq?: (
-      action: 'track' | 'init' | 'trackCustom',
+      action: 'track' | 'init' | 'trackCustom' | 'consent',
       eventName: string,
-      params?: Record<string, unknown>
+      params?: Record<string, unknown>,
+      options?: { eventID?: string }
     ) => void;
   }
 }
@@ -42,8 +44,7 @@ export const trackViewContent = (): void => {
 
 /**
  * Track InitiateCheckout event
- * Should be fired when user starts interacting with the form
- * (e.g., first input focus or CTA button click)
+ * Should be fired when user enters the order form (Step 1 mount)
  * Must fire BEFORE Lead, not instead of it
  */
 export const trackInitiateCheckout = (): void => {
@@ -53,12 +54,35 @@ export const trackInitiateCheckout = (): void => {
 };
 
 /**
- * Track Lead event - PRIMARY CONVERSION
- * Should be fired ONLY after a successful form submission
- * This is the main conversion event for Meta Ads optimization
+ * Track Lead event - MID-FUNNEL INTENT SIGNAL
+ * Should be fired when user completes contact & delivery details (Step 3 → Step 4)
+ * Indicates high-intent user who provided personal data
  */
 export const trackLead = (): void => {
   if (isPixelAvailable()) {
     window.fbq!('track', 'Lead');
+  }
+};
+
+/**
+ * Track Purchase event - PRIMARY CONVERSION
+ * Should be fired ONLY after a successful order creation
+ * This is the main conversion event for Meta Ads optimization
+ * Even without payment, a completed order = completed transaction
+ */
+export const trackPurchase = (params: {
+  value: number;
+  currency: string;
+  contentName?: string;
+  orderId?: string;
+  eventId?: string;
+}): void => {
+  if (isPixelAvailable()) {
+    window.fbq!('track', 'Purchase', {
+      value: params.value,
+      currency: params.currency,
+      content_name: params.contentName,
+      order_id: params.orderId,
+    }, params.eventId ? { eventID: params.eventId } : undefined);
   }
 };

--- a/lib/analytics/subscription.ts
+++ b/lib/analytics/subscription.ts
@@ -19,6 +19,7 @@ export function trackSubscriptionCreated(
   boxType: string,
   frequency: string,
   price: number,
+  eventId?: string,
 ): void {
   if (isGA4Available()) {
     window.gtag!('event', 'subscribe', {
@@ -34,7 +35,7 @@ export function trackSubscriptionCreated(
       frequency,
       value: price,
       currency: 'EUR',
-    });
+    }, eventId ? { eventID: eventId } : undefined);
   }
 }
 

--- a/lib/consent/consentStore.ts
+++ b/lib/consent/consentStore.ts
@@ -18,6 +18,8 @@ interface ConsentState {
   preferences: ConsentPreferences;
   /** Consent record with timestamp and version */
   record: ConsentRecord | null;
+  /** Whether a page refresh is needed after consent downgrade */
+  requiresRefresh: boolean;
 }
 
 interface ConsentActions {
@@ -69,6 +71,41 @@ const clearStorage = (): void => {
   }
 };
 
+/**
+ * Revoke tracking scripts and clear their cookies when consent is downgraded.
+ * Uses Meta's official consent mode and GA4's disable flag.
+ */
+const handleConsentDowngrade = (
+  prevPreferences: ConsentPreferences,
+  newPreferences: ConsentPreferences,
+): boolean => {
+  if (typeof window === 'undefined') return false;
+
+  let downgraded = false;
+
+  // Marketing consent revoked
+  if (prevPreferences.marketing && !newPreferences.marketing) {
+    downgraded = true;
+    // Meta Pixel: official consent revocation - stops new events immediately
+    if (typeof (window as unknown as Record<string, unknown>).fbq === 'function') {
+      (window as unknown as { fbq: (cmd: string, val: string) => void }).fbq('consent', 'revoke');
+    }
+    // Clear Meta tracking cookies (must match domain attribute set by the pixel)
+    document.cookie = '_fbp=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=.fitflow.bg;';
+    document.cookie = '_fbc=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=.fitflow.bg;';
+  }
+
+  // Analytics consent revoked
+  if (prevPreferences.analytics && !newPreferences.analytics) {
+    downgraded = true;
+    // Clear GA4 tracking cookies (must match domain attribute set by GA)
+    document.cookie = '_ga=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=.fitflow.bg;';
+    document.cookie = '_gid=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; domain=.fitflow.bg;';
+  }
+
+  return downgraded;
+};
+
 export const useConsentStore = create<ConsentStore>((set, get) => ({
   // Initial state
   isLoaded: false,
@@ -76,6 +113,7 @@ export const useConsentStore = create<ConsentStore>((set, get) => ({
   showPreferences: false,
   preferences: DEFAULT_PREFERENCES,
   record: null,
+  requiresRefresh: false,
 
   initialize: () => {
     const stored = loadFromStorage();
@@ -129,10 +167,12 @@ export const useConsentStore = create<ConsentStore>((set, get) => ({
       showPreferences: false,
       preferences,
       record,
+      requiresRefresh: false,
     });
   },
 
   rejectNonEssential: () => {
+    const prevPreferences = get().preferences;
     const preferences: ConsentPreferences = {
       necessary: true,
       analytics: false,
@@ -147,15 +187,19 @@ export const useConsentStore = create<ConsentStore>((set, get) => ({
     
     saveToStorage(record);
     
+    const downgraded = handleConsentDowngrade(prevPreferences, preferences);
+    
     set({
       showBanner: false,
       showPreferences: false,
       preferences,
       record,
+      requiresRefresh: downgraded,
     });
   },
 
   savePreferences: (customPreferences) => {
+    const prevPreferences = get().preferences;
     const preferences: ConsentPreferences = {
       necessary: true, // Always true
       analytics: customPreferences.analytics ?? get().preferences.analytics,
@@ -170,11 +214,14 @@ export const useConsentStore = create<ConsentStore>((set, get) => ({
     
     saveToStorage(record);
     
+    const downgraded = handleConsentDowngrade(prevPreferences, preferences);
+    
     set({
       showBanner: false,
       showPreferences: false,
       preferences,
       record,
+      requiresRefresh: downgraded,
     });
   },
 


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #168 

---

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
Upgrades conversion tracking from a single client-side Lead event to a full-funnel setup with server-side redundancy. Orders now fire Purchase (instead of Lead) as the primary conversion — both client-side via Meta Pixel and server-side via Conversions API v21.0 — with event-ID deduplication to prevent double-counting. Subscriptions get a dedicated Subscribe custom event through the same dual pipeline. Lead is repositioned as a mid-funnel intent signal at the contact-details step, and InitiateCheckout fires on form entry, giving Meta Ads three optimisation stages instead of one. On the GDPR side, revoking marketing consent now immediately disables the pixel via fbq('consent', 'revoke'), clears tracking cookies, and prompts a page refresh — closing a gap where scripts continued firing until the next navigation. Non-production environments skip all analytics script rendering and CAPI network calls.

---

## Target branch checklist
- [ ] dev → feature work
- [ ] stage → release candidate
- [x] main → production only

---

## Release intent
- [x] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [ ] This PR does NOT bump versions (required unless targeting main)
- [x] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
