### PR TITLE
[PROD] Add Meta domain verification meta tag

### DIFF
--- a/.changeset/meta-domain-verification.md
+++ b/.changeset/meta-domain-verification.md
@@ -1,0 +1,5 @@
+---
+"fitflow": patch
+---
+
+Add Meta domain verification meta tag for Facebook Business Manager domain ownership verification

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,9 @@ export const metadata: Metadata = {
     type: "website",
     locale: "bg_BG",
   },
+  other: {
+    "facebook-domain-verification": "n8g7hh3b83sgf31873xafdk39027pb",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #172 

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs
- [x] Chore

---

## Description
Adds the facebook-domain-verification meta tag to the site <head> via the Next.js metadata export, enabling Meta Business Manager to verify domain ownership. This unblocks full pixel event attribution and is required before custom conversions or aggregated event measurement can be configured. The tag is static and public by design — no tracking, cookies, or consent implications.

---

## Target branch checklist
- [ ] dev → feature work
- [ ] stage → release candidate
- [x] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [x] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
