### PR TITLE
[STAGE] Correct event placement, add GA4 purchase event, and expand CAPI coverage

### DIFF
--- a/.changeset/fix-analytics-overhaul.md
+++ b/.changeset/fix-analytics-overhaul.md
@@ -1,0 +1,20 @@
+---
+"fitflow": minor
+---
+
+Fix analytics event placement, add GA4 purchase event, and improve Meta CAPI coverage
+
+- Add GA4 `purchase` event (`trackGAPurchase`) — enables revenue reporting in Google Analytics
+- Move `ViewContent` from page-load on 3 pages to order funnel Step 1 with CAPI mirror
+- Move `InitiateCheckout` from Step 1 to Step 3 (checkout details) with `begin_checkout` + CAPI mirror
+- Remove stale `trackLead` and `trackGenerateLead` calls from the order flow
+- Add `trackFormSubmit` on thank-you page for GA4 form completion tracking
+- Create `POST /api/analytics/track` route for client-side CAPI event forwarding (PageView, ViewContent, InitiateCheckout)
+- Add CAPI PageView mirror alongside Facebook Pixel init in ConditionalScripts
+- Add `content_type: 'product'` to all Meta Purchase/Subscribe events (Pixel + CAPI)
+- Add `coupon` param, `item_brand: 'FitFlow'`, `item_list_id`/`item_list_name` to GA4 ecommerce events
+- Consolidate `funnel_step_${name}` into single `funnel_step` event with `step_name` parameter
+- Add `userId` → hashed `external_id` support and `Subscribe` type to CAPI infrastructure
+- Create `useScrollDepth` hook and wire to homepage, mystery box, and revealed box pages
+- Wire `trackSubscriptionPaused` and `trackSubscriptionCancelled` in account modals
+- Create `lib/analytics/cookies.ts` for `_fbp`/`_fbc` extraction

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  sendMetaEvent,
+  type MetaServerEvent,
+  type MetaEventName,
+} from '@/lib/analytics/metaCapi';
+
+/**
+ * POST /api/analytics/track
+ *
+ * Accepts a Meta Pixel event from the client and sends it to CAPI.
+ * Body: { eventName, eventId, customData?, fbp?, fbc?, sourceUrl? }
+ *
+ * The route reads IP and User-Agent from request headers.
+ * This is a fire-and-forget endpoint — always returns 200.
+ */
+
+const ALLOWED_EVENTS: MetaEventName[] = [
+  'PageView',
+  'ViewContent',
+  'InitiateCheckout',
+];
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { eventName, eventId, customData, fbp, fbc, sourceUrl } = body;
+
+    // Validate event name
+    if (!eventName || !ALLOWED_EVENTS.includes(eventName)) {
+      return NextResponse.json({ ok: true }); // Silently ignore
+    }
+
+    if (!eventId || typeof eventId !== 'string') {
+      return NextResponse.json({ ok: true });
+    }
+
+    // Build user data from request headers
+    const clientIp =
+      request.headers.get('x-forwarded-for')?.split(',')[0] ||
+      request.headers.get('x-real-ip') ||
+      '';
+    const userAgent = request.headers.get('user-agent') || '';
+
+    const event: MetaServerEvent = {
+      event_name: eventName,
+      event_time: Math.floor(Date.now() / 1000),
+      event_id: eventId,
+      event_source_url: sourceUrl || request.headers.get('referer') || '',
+      action_source: 'website',
+      data_processing_options: [],
+      user_data: {
+        client_ip_address: clientIp,
+        client_user_agent: userAgent,
+        fbp: fbp || undefined,
+        fbc: fbc || undefined,
+      },
+      custom_data: customData || undefined,
+    };
+
+    // Fire and forget — don't await, don't block the response
+    sendMetaEvent(event).catch((err) => {
+      console.error('[analytics/track] CAPI error:', err);
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    // Never fail — analytics should not break the UX
+    return NextResponse.json({ ok: true });
+  }
+}

--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -771,6 +771,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           value: priceInfo.finalPriceEur,
           content_name: effectiveBoxType,
           content_category: 'order',
+          content_type: 'product',
           order_id: order.id,
         },
       });

--- a/app/api/subscription/route.ts
+++ b/app/api/subscription/route.ts
@@ -520,6 +520,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           value: priceInfo.finalPriceEur,
           content_name: effectiveBoxType,
           content_category: 'subscription',
+          content_type: 'product',
         },
       });
 

--- a/app/order/thank-you/page.tsx
+++ b/app/order/thank-you/page.tsx
@@ -6,7 +6,8 @@ import Link from 'next/link';
 import { useOrderStore } from '@/store/orderStore';
 import {
   trackPurchase,
-  trackGenerateLead,
+  trackGAPurchase,
+  trackFormSubmit,
   setUserProperties,
 } from '@/lib/analytics';
 import { trackSubscriptionCreated } from '@/lib/analytics/subscription';
@@ -73,15 +74,26 @@ export default function OrderThankYou() {
       });
     }
 
-    // GA4 - generate_lead event
-    trackGenerateLead({
-      currency: 'EUR',
+    // GA4 — purchase event (critical for revenue reporting)
+    trackGAPurchase({
+      transaction_id: orderInfo.orderId ?? orderInfo.orderNumber ?? 'unknown',
       value: orderInfo.finalPriceEur ?? 0,
+      currency: 'EUR',
+      items: [{
+        item_id: orderInfo.boxType ?? 'fitflow-box',
+        item_name: orderInfo.boxType ?? 'FitFlow Box',
+        item_brand: 'FitFlow',
+        price: orderInfo.finalPriceEur ?? 0,
+        quantity: 1,
+      }],
     });
 
-    // GA4 - user properties
+    // GA4 — form submission completed
+    trackFormSubmit({ form_name: 'order', success: true });
+
+    // GA4 — user properties
     setUserProperties({
-      promo_code_used: false, // order completed
+      promo_code_used: false,
     });
 
     hasTracked.current = true;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,13 +3,14 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef, useState, Suspense, Fragment, useMemo } from 'react';
+import { useEffect, useState, Suspense, Fragment, useMemo } from 'react';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import HowItWorks from '@/components/HowItWorks';
 import { useOrderStore } from '@/store/orderStore';
 import { useDeliveryStore } from '@/store/deliveryStore';
-import { trackViewContent, trackViewItem, trackCTAClick, trackPromoCode } from '@/lib/analytics';
+import { trackCTAClick, trackPromoCode } from '@/lib/analytics';
+import { useScrollDepth } from '@/lib/analytics/useScrollDepth';
 import { formatDeliveryDate, formatMonthYear } from '@/lib/delivery';
 import { formatPrice } from '@/lib/catalog';
 import type { PricesMap } from '@/lib/catalog';
@@ -17,7 +18,7 @@ import type { PricesMap } from '@/lib/catalog';
 function HomeContent() {
   const searchParams = useSearchParams();
   const { setPromoCode } = useOrderStore();
-  const hasTrackedViewContent = useRef(false);
+  useScrollDepth([25, 50, 75, 100], 'homepage');
   const {
     revealedBox: rawRevealedBox, fetchRevealedBox,
     upcomingDelivery, fetchUpcomingDelivery,
@@ -51,20 +52,6 @@ function HomeContent() {
       monthYear: formatMonthYear(rawRevealedBox.cycle.deliveryDate),
     };
   }, [rawRevealedBox]);
-  
-  // Track ViewContent (Meta) and view_item (GA4) on landing page load (once)
-  useEffect(() => {
-    if (!hasTrackedViewContent.current) {
-      // Meta Pixel
-      trackViewContent();
-      // GA4
-      trackViewItem({
-        item_id: 'fitflow-box',
-        item_name: 'FitFlow Box',
-      });
-      hasTrackedViewContent.current = true;
-    }
-  }, []);
   
   // Extract promo code from URL and validate via API
   // Fix P3: Only validate if URL code differs from stored code

--- a/components/ConditionalScripts.tsx
+++ b/components/ConditionalScripts.tsx
@@ -61,20 +61,43 @@ export default function ConditionalScripts({
 
       {/* Facebook Pixel - requires marketing consent */}
       {preferences.marketing && facebookPixelId && (
-        <Script id="facebook-pixel" strategy="afterInteractive">
-          {`
-            !function(f,b,e,v,n,t,s)
-            {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-            n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-            if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-            n.queue=[];t=b.createElement(e);t.async=!0;
-            t.src=v;s=b.getElementsByTagName(e)[0];
-            s.parentNode.insertBefore(t,s)}(window, document,'script',
-            'https://connect.facebook.net/en_US/fbevents.js');
-            fbq('init', '${facebookPixelId}');
-            fbq('track', 'PageView');
-          `}
-        </Script>
+        <>
+          <Script id="facebook-pixel" strategy="afterInteractive">
+            {`
+              !function(f,b,e,v,n,t,s)
+              {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+              n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];
+              s.parentNode.insertBefore(t,s)}(window, document,'script',
+              'https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '${facebookPixelId}');
+              fbq('track', 'PageView');
+            `}
+          </Script>
+          <Script id="capi-pageview" strategy="afterInteractive">
+            {`
+              (function() {
+                var eventId = Date.now() + '-' + Math.random().toString(36).substring(2, 15);
+                var fbp = (document.cookie.match(/(?:^|;\\s*)_fbp=([^;]*)/) || [])[1];
+                var fbc = (document.cookie.match(/(?:^|;\\s*)_fbc=([^;]*)/) || [])[1];
+                fetch('/api/analytics/track', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    eventName: 'PageView',
+                    eventId: eventId,
+                    fbp: fbp || undefined,
+                    fbc: fbc || undefined,
+                    sourceUrl: window.location.href
+                  }),
+                  keepalive: true
+                }).catch(function(){});
+              })();
+            `}
+          </Script>
+        </>
       )}
 
       {/* Google Ads - requires marketing consent */}

--- a/components/account/SubscriptionCard.tsx
+++ b/components/account/SubscriptionCard.tsx
@@ -385,6 +385,7 @@ export default function SubscriptionCard({
       {activeModal === 'pause' && (
         <PauseModal
           subscriptionId={subscription.id}
+          boxType={subscription.box_type}
           onSuccess={handleActionSuccess}
           onClose={closeModal}
         />
@@ -400,6 +401,7 @@ export default function SubscriptionCard({
       {activeModal === 'cancel' && (
         <CancelModal
           subscriptionId={subscription.id}
+          boxType={subscription.box_type}
           onSuccess={handleActionSuccess}
           onPauseInstead={() => {
             setActiveModal('pause');

--- a/components/account/modals/CancelModal.tsx
+++ b/components/account/modals/CancelModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { trackSubscriptionCancelled } from '@/lib/analytics/subscription';
 
 const CANCELLATION_REASONS = [
   'Твърде скъпо',
@@ -12,6 +13,7 @@ const CANCELLATION_REASONS = [
 
 interface CancelModalProps {
   subscriptionId: string;
+  boxType: string;
   onSuccess: () => void;
   onPauseInstead: () => void;
   onClose: () => void;
@@ -19,6 +21,7 @@ interface CancelModalProps {
 
 export default function CancelModal({
   subscriptionId,
+  boxType,
   onSuccess,
   onPauseInstead,
   onClose,
@@ -53,6 +56,7 @@ export default function CancelModal({
       }
 
       onSuccess();
+      trackSubscriptionCancelled(boxType, finalReason!);
     } catch {
       setError('Възникна грешка. Моля, опитайте отново.');
     } finally {

--- a/components/account/modals/PauseModal.tsx
+++ b/components/account/modals/PauseModal.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import { useState } from 'react';
+import { trackSubscriptionPaused } from '@/lib/analytics/subscription';
 
 interface PauseModalProps {
   subscriptionId: string;
+  boxType: string;
   onSuccess: () => void;
   onClose: () => void;
 }
 
-export default function PauseModal({ subscriptionId, onSuccess, onClose }: PauseModalProps) {
+export default function PauseModal({ subscriptionId, boxType, onSuccess, onClose }: PauseModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -29,6 +31,7 @@ export default function PauseModal({ subscriptionId, onSuccess, onClose }: Pause
       }
 
       onSuccess();
+      trackSubscriptionPaused(boxType);
     } catch {
       setError('Възникна грешка. Моля, опитайте отново.');
     } finally {

--- a/components/box/MysteryBoxContent.tsx
+++ b/components/box/MysteryBoxContent.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import PriceDisplay from '@/components/PriceDisplay';
 import HowItWorks from '@/components/HowItWorks';
 import { useOrderStore } from '@/store/orderStore';
-import { trackViewContent, trackViewItem, trackCTAClick } from '@/lib/analytics';
+import { trackCTAClick } from '@/lib/analytics';
+import { useScrollDepth } from '@/lib/analytics/useScrollDepth';
 import type { PricesMap, PriceInfo } from '@/lib/catalog';
 
 interface UpcomingCycleInfo {
@@ -27,21 +28,9 @@ export default function MysteryBoxContent({
   nextDeliveryDate,
 }: MysteryBoxContentProps) {
   const router = useRouter();
-  const hasTracked = useRef(false);
   const { promoCode } = useOrderStore();
+  useScrollDepth([50, 100], 'mystery-box');
   const [livePrices, setLivePrices] = useState<PricesMap>(prices);
-
-  // Analytics on mount
-  useEffect(() => {
-    if (!hasTracked.current) {
-      trackViewContent();
-      trackViewItem({
-        item_id: 'mystery-box',
-        item_name: 'Mystery Box',
-      });
-      hasTracked.current = true;
-    }
-  }, []);
 
   // Refresh prices when promo code changes
   useEffect(() => {

--- a/components/box/RevealedBoxContent.tsx
+++ b/components/box/RevealedBoxContent.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import PriceDisplay from '@/components/PriceDisplay';
 import { useOrderStore } from '@/store/orderStore';
-import { trackViewContent, trackViewItem, trackCTAClick } from '@/lib/analytics';
+import { trackCTAClick } from '@/lib/analytics';
+import { useScrollDepth } from '@/lib/analytics/useScrollDepth';
 import type { PricesMap, PriceInfo } from '@/lib/catalog';
 
 // ---------------------------------------------------------------------------
@@ -65,21 +66,9 @@ export default function RevealedBoxContent({
   monthYear,
 }: RevealedBoxContentProps) {
   const router = useRouter();
-  const hasTracked = useRef(false);
   const { promoCode } = useOrderStore();
+  useScrollDepth([50, 100], 'revealed-box');
   const [livePrices, setLivePrices] = useState<PricesMap>(prices);
-
-  // Analytics on mount
-  useEffect(() => {
-    if (!hasTracked.current) {
-      trackViewContent();
-      trackViewItem({
-        item_id: 'revealed-box',
-        item_name: `Revealed Box ${monthYear}`,
-      });
-      hasTracked.current = true;
-    }
-  }, [monthYear]);
 
   // Refresh prices when promo code changes
   useEffect(() => {

--- a/components/order/OrderStepBox.tsx
+++ b/components/order/OrderStepBox.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useOrderStore } from '@/store/orderStore';
-import { trackFunnelStep, trackBoxSelection, trackInitiateCheckout } from '@/lib/analytics';
+import { trackFunnelStep, trackBoxSelection, trackViewContent, generateEventId, getMetaClientContext } from '@/lib/analytics';
 import PriceDisplay from '@/components/PriceDisplay';
 import type { PricesMap, BoxTypeId, PriceInfo } from '@/lib/catalog';
 import { getDisplayBoxType, getPremiumFrequency, buildBoxTypeId } from '@/lib/catalog';
@@ -18,11 +18,30 @@ export default function OrderStepBox({ prices, boxTypeNames, onNext }: OrderStep
   const { boxType, setBoxType, setFrequency, promoCode } = useOrderStore();
   const hasTrackedStep = useRef(false);
 
-  // Track funnel step + InitiateCheckout on mount
+  // Track funnel step + ViewContent on mount
   useEffect(() => {
     if (!hasTrackedStep.current) {
       trackFunnelStep('box_selection', 1);
-      trackInitiateCheckout();
+
+      // Meta Pixel — ViewContent (user sees box selection = product page)
+      const eventId = generateEventId();
+      trackViewContent({ contentName: 'box_selection', eventId });
+
+      // CAPI mirror — fire and forget
+      const { fbp, fbc, sourceUrl } = getMetaClientContext();
+      fetch('/api/analytics/track', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventName: 'ViewContent',
+          eventId,
+          fbp,
+          fbc,
+          sourceUrl,
+          customData: { content_name: 'box_selection' },
+        }),
+      }).catch(() => {});
+
       hasTrackedStep.current = true;
     }
   }, []);

--- a/components/order/OrderStepDetails.tsx
+++ b/components/order/OrderStepDetails.tsx
@@ -3,7 +3,14 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useOrderStore } from '@/store/orderStore';
 import { useAuthStore } from '@/store/authStore';
-import { trackFunnelStep, trackFormInteraction, trackLead } from '@/lib/analytics';
+import {
+  trackFunnelStep,
+  trackFormInteraction,
+  trackInitiateCheckout,
+  trackBeginCheckout,
+  generateEventId,
+  getMetaClientContext,
+} from '@/lib/analytics';
 import { isValidEmail, isValidPhone, getEmailError, getPhoneError } from '@/lib/catalog';
 import { isSubscriptionBox } from '@/lib/catalog';
 import { getAddressFieldError, validateAddress, validateSpeedyOffice } from '@/lib/order';
@@ -41,12 +48,33 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
   const onBehalfOfUserId = useOrderStore((s) => s.onBehalfOfUserId);
   const conversionToken = useOrderStore((s) => s.conversionToken);
   const hasTrackedStep = useRef(false);
-  const hasTrackedLead = useRef(false);
 
-  // Track funnel step on mount
+  // Track funnel step + InitiateCheckout + BeginCheckout on mount
   useEffect(() => {
     if (!hasTrackedStep.current) {
       trackFunnelStep('contact_info', 3);
+
+      // Meta Pixel — InitiateCheckout (user enters checkout phase)
+      const eventId = generateEventId();
+      trackInitiateCheckout({ contentName: 'checkout_details', eventId });
+
+      // GA4 — begin_checkout
+      trackBeginCheckout();
+
+      // CAPI mirror — fire and forget
+      const { fbp, fbc, sourceUrl } = getMetaClientContext();
+      fetch('/api/analytics/track', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventName: 'InitiateCheckout',
+          eventId,
+          fbp,
+          fbc,
+          sourceUrl,
+        }),
+      }).catch(() => {});
+
       hasTrackedStep.current = true;
     }
   }, []);
@@ -268,10 +296,6 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
 
     // Fire Lead event once when user completes Step 3 (mid-funnel intent signal)
     const advanceToNext = () => {
-      if (!hasTrackedLead.current) {
-        trackLead();
-        hasTrackedLead.current = true;
-      }
       onNext();
     };
 

--- a/lib/analytics/cookies.ts
+++ b/lib/analytics/cookies.ts
@@ -1,0 +1,46 @@
+/**
+ * Client-side cookie helpers for Meta CAPI integration.
+ *
+ * Reads _fbp (Facebook browser ID) and _fbc (Facebook click ID) cookies
+ * set by the Meta Pixel, plus captures the current page URL for
+ * event_source_url.
+ */
+
+/** Extract a cookie value by name from document.cookie. */
+function getCookie(name: string): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : undefined;
+}
+
+/** Return the Meta _fbp cookie if present. */
+export function getFbp(): string | undefined {
+  return getCookie('_fbp');
+}
+
+/** Return the Meta _fbc cookie if present. */
+export function getFbc(): string | undefined {
+  return getCookie('_fbc');
+}
+
+/** Return the current page URL (for CAPI event_source_url). */
+export function getSourceUrl(): string {
+  if (typeof window === 'undefined') return '';
+  return window.location.href;
+}
+
+/**
+ * Collect all Meta-related client context in one call.
+ * Useful before POST-ing to /api/analytics/track.
+ */
+export function getMetaClientContext(): {
+  fbp?: string;
+  fbc?: string;
+  sourceUrl: string;
+} {
+  return {
+    fbp: getFbp(),
+    fbc: getFbc(),
+    sourceUrl: getSourceUrl(),
+  };
+}

--- a/lib/analytics/ga4.ts
+++ b/lib/analytics/ga4.ts
@@ -45,6 +45,7 @@ export const trackViewItem = (params?: {
   item_name?: string;
   currency?: string;
   value?: number;
+  coupon?: string;
 }): void => {
   if (isGA4Available()) {
     window.gtag!('event', 'view_item', {
@@ -52,8 +53,10 @@ export const trackViewItem = (params?: {
       items: [{
         item_id: params?.item_id || 'fitflow-box',
         item_name: params?.item_name || 'FitFlow Box',
+        item_brand: 'FitFlow',
       }],
       value: params?.value,
+      coupon: params?.coupon,
       ...params,
     });
   }
@@ -67,9 +70,11 @@ export const trackViewItem = (params?: {
 export const trackBeginCheckout = (params?: {
   currency?: string;
   value?: number;
+  coupon?: string;
   items?: Array<{
     item_id: string;
     item_name: string;
+    item_brand?: string;
     price?: number;
   }>;
 }): void => {
@@ -77,9 +82,11 @@ export const trackBeginCheckout = (params?: {
     window.gtag!('event', 'begin_checkout', {
       currency: params?.currency || 'EUR',
       value: params?.value,
+      coupon: params?.coupon,
       items: params?.items || [{
         item_id: 'fitflow-box',
         item_name: 'FitFlow Box',
+        item_brand: 'FitFlow',
       }],
     });
   }
@@ -98,6 +105,39 @@ export const trackGenerateLead = (params?: {
     window.gtag!('event', 'generate_lead', {
       currency: params?.currency || 'EUR',
       value: params?.value || 0,
+    });
+  }
+};
+
+/**
+ * Track purchase event (GA4 recommended event)
+ * Fired on successful order completion — PRIMARY CONVERSION for revenue
+ * Maps to Meta's Purchase
+ */
+export const trackGAPurchase = (params: {
+  transaction_id: string;
+  value: number;
+  currency?: string;
+  coupon?: string;
+  items: Array<{
+    item_id: string;
+    item_name: string;
+    item_brand?: string;
+    price?: number;
+    quantity?: number;
+  }>;
+}): void => {
+  if (isGA4Available()) {
+    window.gtag!('event', 'purchase', {
+      transaction_id: params.transaction_id,
+      value: params.value,
+      currency: params.currency || 'EUR',
+      coupon: params.coupon,
+      items: params.items.map(item => ({
+        ...item,
+        item_brand: item.item_brand || 'FitFlow',
+        quantity: item.quantity || 1,
+      })),
     });
   }
 };
@@ -122,7 +162,7 @@ export const trackFunnelStep = (
   params?: Record<string, unknown>
 ): void => {
   if (isGA4Available()) {
-    window.gtag!('event', `funnel_step_${step}`, {
+    window.gtag!('event', 'funnel_step', {
       step_number: stepNumber,
       step_name: step,
       ...params,
@@ -143,9 +183,12 @@ export const trackBoxSelection = (params: {
 }): void => {
   if (isGA4Available()) {
     window.gtag!('event', 'select_item', {
+      item_list_id: 'box_selection',
+      item_list_name: 'Box Selection',
       items: [{
         item_id: params.box_type,
         item_name: params.box_name,
+        item_brand: 'FitFlow',
         price: params.price,
         currency: params.currency || 'EUR',
       }],

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -21,6 +21,7 @@ export {
   trackInitiateCheckoutCapi,
   trackPurchaseCapi,
   trackSubscribeCapi,
+  trackPageViewCapi,
   // Types
   type MetaEventName,
   type MetaUserData,
@@ -35,6 +36,7 @@ export {
   trackViewItem,
   trackBeginCheckout,
   trackGenerateLead,
+  trackGAPurchase,
   // Funnel events
   trackFunnelStep,
   trackBoxSelection,
@@ -52,3 +54,9 @@ export {
   // Types
   type FunnelStep,
 } from './ga4';
+
+// Client cookie helpers
+export { getFbp, getFbc, getSourceUrl, getMetaClientContext } from './cookies';
+
+// Hooks
+export { useScrollDepth } from './useScrollDepth';

--- a/lib/analytics/metaCapi.ts
+++ b/lib/analytics/metaCapi.ts
@@ -15,7 +15,8 @@
  */
 
 // Meta CAPI endpoint
-const META_CAPI_ENDPOINT = 'https://graph.facebook.com/v21.0';
+const META_GRAPH_API_VERSION = 'v21.0';
+const META_CAPI_ENDPOINT = `https://graph.facebook.com/${META_GRAPH_API_VERSION}`;
 
 // Event names matching browser pixel events
 export type MetaEventName = 
@@ -23,7 +24,8 @@ export type MetaEventName =
   | 'ViewContent'
   | 'InitiateCheckout'
   | 'Lead'
-  | 'Purchase';
+  | 'Purchase'
+  | 'Subscribe';
 
 // User data for matching (hashed on client, sent as-is here)
 export interface MetaUserData {
@@ -90,6 +92,7 @@ export async function buildCapiUserData(opts: {
   fullName?: string;
   fbc?: string;
   fbp?: string;
+  userId?: string;
 }): Promise<{ userData: MetaUserData; referer: string }> {
   const clientIp =
     opts.headersObj.get('x-forwarded-for')?.split(',')[0] ||
@@ -102,11 +105,12 @@ export async function buildCapiUserData(opts: {
   const firstName = nameParts[0] || '';
   const lastName = nameParts.slice(1).join(' ') || '';
 
-  const [hashedEmail, hashedPhone, hashedFirstName, hashedLastName] = await Promise.all([
+  const [hashedEmail, hashedPhone, hashedFirstName, hashedLastName, hashedUserId] = await Promise.all([
     opts.email ? hashForMeta(opts.email) : Promise.resolve(undefined),
     opts.phone ? hashForMeta(opts.phone) : Promise.resolve(undefined),
     firstName ? hashForMeta(firstName) : Promise.resolve(undefined),
     lastName ? hashForMeta(lastName) : Promise.resolve(undefined),
+    opts.userId ? hashForMeta(opts.userId) : Promise.resolve(undefined),
   ]);
 
   return {
@@ -119,6 +123,7 @@ export async function buildCapiUserData(opts: {
       client_user_agent: userAgent,
       fbc: opts.fbc,
       fbp: opts.fbp,
+      external_id: hashedUserId,
     },
     referer,
   };
@@ -243,6 +248,7 @@ export async function sendMetaEvents(events: MetaServerEvent[]): Promise<{ succe
 /**
  * Track Lead event via CAPI (primary conversion)
  * Call this from your API route after successful form submission
+ * @note For deduplication: pass the same eventId to both the browser pixel call and this CAPI call.
  */
 export async function trackLeadCapi(params: {
   eventId: string;
@@ -266,6 +272,7 @@ export async function trackLeadCapi(params: {
 
 /**
  * Track ViewContent event via CAPI
+ * @note For deduplication: pass the same eventId to both the browser pixel call and this CAPI call.
  */
 export async function trackViewContentCapi(params: {
   eventId: string;
@@ -289,6 +296,7 @@ export async function trackViewContentCapi(params: {
 
 /**
  * Track InitiateCheckout event via CAPI
+ * @note For deduplication: pass the same eventId to both the browser pixel call and this CAPI call.
  */
 export async function trackInitiateCheckoutCapi(params: {
   eventId: string;
@@ -313,6 +321,7 @@ export async function trackInitiateCheckoutCapi(params: {
 /**
  * Track Purchase event via CAPI (primary conversion)
  * Call this from your API route after successful order creation
+ * @note For deduplication: pass the same eventId to both the browser pixel call and this CAPI call.
  */
 export async function trackPurchaseCapi(params: {
   eventId: string;
@@ -337,6 +346,7 @@ export async function trackPurchaseCapi(params: {
 /**
  * Track Subscribe custom event via CAPI
  * Call this from your subscription API route after successful creation
+ * @note For deduplication: pass the same eventId to both the browser pixel call and this CAPI call.
  */
 export async function trackSubscribeCapi(params: {
   eventId: string;
@@ -353,6 +363,29 @@ export async function trackSubscribeCapi(params: {
     data_processing_options: [],
     user_data: params.userData,
     custom_data: params.customData,
+  };
+
+  return sendMetaEvent(event);
+}
+
+/**
+ * Track PageView event via CAPI
+ * Mirror of the automatic browser-side PageView fired by the pixel init.
+ * Requires eventID for deduplication with the browser pixel's PageView.
+ */
+export async function trackPageViewCapi(params: {
+  eventId: string;
+  sourceUrl: string;
+  userData: MetaUserData;
+}): Promise<{ success: boolean; error?: string }> {
+  const event: MetaServerEvent = {
+    event_name: 'PageView',
+    event_time: Math.floor(Date.now() / 1000),
+    event_id: params.eventId,
+    event_source_url: params.sourceUrl,
+    action_source: 'website',
+    data_processing_options: [],
+    user_data: params.userData,
   };
 
   return sendMetaEvent(event);

--- a/lib/analytics/metaPixel.ts
+++ b/lib/analytics/metaPixel.ts
@@ -36,9 +36,26 @@ export const isPixelAvailable = (): boolean => {
  * Should be fired once on landing page load
  * Do NOT fire on thank-you page, privacy policy, or other utility pages
  */
-export const trackViewContent = (): void => {
+export const trackViewContent = (params?: {
+  contentName?: string;
+  contentCategory?: string;
+  value?: number;
+  currency?: string;
+  eventId?: string;
+}): void => {
   if (isPixelAvailable()) {
-    window.fbq!('track', 'ViewContent');
+    const data: Record<string, unknown> = {};
+    if (params?.contentName) data.content_name = params.contentName;
+    if (params?.contentCategory) data.content_category = params.contentCategory;
+    if (params?.value !== undefined) data.value = params.value;
+    if (params?.currency) data.currency = params.currency;
+
+    window.fbq!(
+      'track',
+      'ViewContent',
+      Object.keys(data).length > 0 ? data : undefined,
+      params?.eventId ? { eventID: params.eventId } : undefined,
+    );
   }
 };
 
@@ -47,9 +64,26 @@ export const trackViewContent = (): void => {
  * Should be fired when user enters the order form (Step 1 mount)
  * Must fire BEFORE Lead, not instead of it
  */
-export const trackInitiateCheckout = (): void => {
+export const trackInitiateCheckout = (params?: {
+  value?: number;
+  currency?: string;
+  contentName?: string;
+  numItems?: number;
+  eventId?: string;
+}): void => {
   if (isPixelAvailable()) {
-    window.fbq!('track', 'InitiateCheckout');
+    const data: Record<string, unknown> = {};
+    if (params?.value !== undefined) data.value = params.value;
+    if (params?.currency) data.currency = params.currency;
+    if (params?.contentName) data.content_name = params.contentName;
+    if (params?.numItems !== undefined) data.num_items = params.numItems;
+
+    window.fbq!(
+      'track',
+      'InitiateCheckout',
+      Object.keys(data).length > 0 ? data : undefined,
+      params?.eventId ? { eventID: params.eventId } : undefined,
+    );
   }
 };
 
@@ -58,9 +92,16 @@ export const trackInitiateCheckout = (): void => {
  * Should be fired when user completes contact & delivery details (Step 3 → Step 4)
  * Indicates high-intent user who provided personal data
  */
-export const trackLead = (): void => {
+export const trackLead = (params?: {
+  eventId?: string;
+}): void => {
   if (isPixelAvailable()) {
-    window.fbq!('track', 'Lead');
+    window.fbq!(
+      'track',
+      'Lead',
+      undefined,
+      params?.eventId ? { eventID: params.eventId } : undefined,
+    );
   }
 };
 
@@ -82,6 +123,7 @@ export const trackPurchase = (params: {
       value: params.value,
       currency: params.currency,
       content_name: params.contentName,
+      content_type: 'product',
       order_id: params.orderId,
     }, params.eventId ? { eventID: params.eventId } : undefined);
   }

--- a/lib/analytics/useScrollDepth.ts
+++ b/lib/analytics/useScrollDepth.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { trackScrollDepth } from './ga4';
+
+/**
+ * Hook that fires GA4 scroll_depth events at specified percentage thresholds.
+ * Each threshold fires only once per mount.
+ *
+ * @param thresholds - Array of percentages to track, e.g. [25, 50, 75, 100]
+ * @param pageLocation - Identifier for the page (e.g. 'homepage', 'mystery-box')
+ */
+export function useScrollDepth(
+  thresholds: number[],
+  pageLocation: string,
+): void {
+  const firedRef = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    const fired = firedRef.current;
+
+    function handleScroll() {
+      const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+      if (scrollHeight <= 0) return;
+
+      const percent = Math.round((window.scrollY / scrollHeight) * 100);
+
+      for (const threshold of thresholds) {
+        if (percent >= threshold && !fired.has(threshold)) {
+          fired.add(threshold);
+          trackScrollDepth({
+            percent_scrolled: threshold,
+            page_location: pageLocation,
+          });
+        }
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [thresholds, pageLocation]);
+}


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Issue #176

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs
- [x] Chore

---

## Description
Analytics events were firing at incorrect funnel stages (ViewContent on page load, InitiateCheckout at box selection), GA4 had no purchase event so zero revenue data was flowing into Google Analytics, and mid-funnel events lacked server-side CAPI mirrors making them vulnerable to ad blockers. This PR corrects the event placement across the order funnel, adds the critical GA4 purchase event on the thank-you page, creates a /api/analytics/track endpoint for client-to-CAPI forwarding of ViewContent/InitiateCheckout/PageView, adds [content_type](vscode-file://vscode-app/c:/Users/angelnik/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [item_brand](vscode-file://vscode-app/c:/Users/angelnik/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [coupon](vscode-file://vscode-app/c:/Users/angelnik/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) params per Meta and GA4 documentation requirements, wires previously-unused subscription pause/cancel tracking, and introduces scroll depth tracking on key landing pages — all validated with tsc --noEmit across 19 files (427 additions, 88 deletions).

---

## Target branch checklist
- [ ] dev → feature work
- [x] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
