### PR TITLE
[DEV] Consolidate date/time formatting and fix rendering bugs

### DIFF
--- a/.changeset/fix-date-formats.md
+++ b/.changeset/fix-date-formats.md
@@ -1,0 +1,5 @@
+---
+"fitflow": patch
+---
+
+Consolidate all date/time formatting into a shared `lib/utils/date.ts` module with 6 canonical functions. Removes 18 duplicated local helpers across ~25 files. Fixes raw ISO timestamps rendering on admin subscription pages, 2-digit year in email log table, and inconsistent bare-locale date formats. Admin order/subscription dates now show both date and time.

--- a/app/account/orders/[orderNumber]/page.tsx
+++ b/app/account/orders/[orderNumber]/page.tsx
@@ -20,6 +20,7 @@ import {
   formatDeliveryMethodLabel,
 } from '@/lib/order';
 import { formatPriceDual } from '@/lib/catalog';
+import { formatDateLong } from '@/lib/utils/date';
 import { StatusTimeline } from '@/components/account/StatusTimeline';
 import { CancelRequestButton } from '@/components/account/CancelRequestButton';
 import type { OrderStatus } from '@/lib/supabase/types';
@@ -41,18 +42,6 @@ export async function generateMetadata({
       ? `Поръчка ${formatOrderNumber(order.order_number)} | FitFlow`
       : 'Поръчка | FitFlow',
   };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatDateBG(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('bg-BG', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -96,14 +85,14 @@ export default async function OrderDetailPage({
   // Derived dates
   const lastUpdateDate =
     statusHistory.length > 0
-      ? formatDateBG(statusHistory[statusHistory.length - 1].created_at)
+      ? formatDateLong(statusHistory[statusHistory.length - 1].created_at)
       : null;
   const expectedDeliveryDate = deliveryCycle?.delivery_date
-    ? formatDateBG(deliveryCycle.delivery_date)
+    ? formatDateLong(deliveryCycle.delivery_date)
     : null;
   const nextRenewalDate =
     order.order_type === 'subscription' && upcomingCycle?.delivery_date
-      ? formatDateBG(upcomingCycle.delivery_date)
+      ? formatDateLong(upcomingCycle.delivery_date)
       : null;
 
   const canCancel = statusKey === 'pending' || statusKey === 'confirmed';
@@ -187,7 +176,7 @@ export default async function OrderDetailPage({
           <div>
             <dt className="text-gray-500 mb-1">Дата на поръчка</dt>
             <dd className="font-semibold text-gray-900">
-              {formatDateBG(order.created_at)}
+              {formatDateLong(order.created_at)}
             </dd>
           </div>
           {lastUpdateDate && (

--- a/app/account/orders/preorder/[preorderNumber]/page.tsx
+++ b/app/account/orders/preorder/[preorderNumber]/page.tsx
@@ -12,6 +12,7 @@ import {
   PREORDER_STATUS_COLORS,
 } from '@/lib/order';
 import { formatPriceDual } from '@/lib/catalog';
+import { formatDateLong } from '@/lib/utils/date';
 import type { Metadata } from 'next';
 
 // ---------------------------------------------------------------------------
@@ -21,18 +22,6 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Предварителна поръчка | FitFlow',
 };
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatDateBG(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('bg-BG', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Page
@@ -141,7 +130,7 @@ export default async function PreorderDetailPage({
           {/* Created date */}
           <div>
             <span className="text-sm text-gray-500">Дата на създаване</span>
-            <p className="font-medium">{formatDateBG(preorder.created_at)}</p>
+            <p className="font-medium">{formatDateLong(preorder.created_at)}</p>
           </div>
 
           {/* Box type */}
@@ -195,7 +184,7 @@ export default async function PreorderDetailPage({
             <div>
               <span className="text-sm text-gray-500">Изтича на</span>
               <p className="font-medium">
-                {formatDateBG(preorder.conversion_token_expires_at!)}
+                {formatDateLong(preorder.conversion_token_expires_at!)}
               </p>
             </div>
           )}
@@ -249,7 +238,7 @@ export default async function PreorderDetailPage({
           </Link>
           {expiresAt && (
             <p className="text-sm text-gray-500 mt-2">
-              Валидна до {formatDateBG(preorder.conversion_token_expires_at!)}
+              Валидна до {formatDateLong(preorder.conversion_token_expires_at!)}
             </p>
           )}
         </div>

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,5 +1,6 @@
 import { requireAuth } from '@/lib/auth';
 import { getPreordersByUser } from '@/lib/data';
+import { formatDateShort } from '@/lib/utils/date';
 import PasswordSetupBanner from '@/components/account/PasswordSetupBanner';
 import UnlinkedPreordersBanner from '@/components/account/UnlinkedPreordersBanner';
 import ExpiringPreordersBanner from '@/components/account/ExpiringPreordersBanner';
@@ -60,7 +61,7 @@ export default async function AccountPage() {
         <div>
           <span className="text-sm text-gray-500">Акаунт създаден</span>
           <p className="text-lg font-medium">
-            {new Date(profile.created_at).toLocaleDateString('bg-BG')}
+            {formatDateShort(profile.created_at)}
           </p>
         </div>
       </div>

--- a/app/admin/campaigns/page.tsx
+++ b/app/admin/campaigns/page.tsx
@@ -4,6 +4,7 @@ import CampaignStatusBadge from '@/components/admin/CampaignStatusBadge';
 import CampaignTypeBadge from '@/components/admin/CampaignTypeBadge';
 import { AdminHelpLink } from '@/components/admin/AdminHelpLink';
 import Link from 'next/link';
+import { formatDateTimeShort, formatRelative } from '@/lib/utils/date';
 import type { Metadata } from 'next';
 import type { EmailCampaignStatusEnum, EmailCampaignTypeEnum } from '@/lib/supabase/types';
 
@@ -246,8 +247,8 @@ export default async function CampaignsPage({ searchParams }: CampaignsPageProps
                             )}
                           </div>
                         </td>
-                        <td className="px-4 py-3 text-gray-500" title={new Date(c.created_at).toLocaleString('bg-BG')}>
-                          {relativeDate(c.created_at)}
+                        <td className="px-4 py-3 text-gray-500" title={formatDateTimeShort(c.created_at)}>
+                          {formatRelative(c.created_at)}
                         </td>
                         <td className="px-4 py-3">
                           <Link

--- a/app/admin/customers/[id]/page.tsx
+++ b/app/admin/customers/[id]/page.tsx
@@ -12,6 +12,7 @@ import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import type { SubscriptionRow, OrderRow, OrderStatus, SubscriptionStatus } from '@/lib/supabase/types';
 import AdminAddressManager from '@/components/admin/AdminAddressManager';
+import { formatDateTimeShort } from '@/lib/utils/date';
 
 export const metadata: Metadata = {
   title: 'Клиент | Администрация | FitFlow',
@@ -40,10 +41,6 @@ function StatusBadge({ label, className }: { label: string; className: string })
       {label}
     </span>
   );
-}
-
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString('bg-BG');
 }
 
 function formatPrice(eur: number | null) {
@@ -95,7 +92,7 @@ export default async function CustomerDetailPage({ params }: { params: Promise<{
           <p><span className="font-medium text-gray-700">Имейл:</span> {email}</p>
           <p><span className="font-medium text-gray-700">Телефон:</span> {profile.phone ?? '—'}</p>
           <p><span className="font-medium text-gray-700">Тип:</span> {profile.user_type === 'staff' ? 'Персонал' : 'Клиент'}</p>
-          <p><span className="font-medium text-gray-700">Регистрация:</span> {authCreatedAt ? formatDate(authCreatedAt) : formatDate(profile.created_at)}</p>
+          <p><span className="font-medium text-gray-700">Регистрация:</span> {authCreatedAt ? formatDateTimeShort(authCreatedAt) : formatDateTimeShort(profile.created_at)}</p>
         </div>
         <div className="flex flex-wrap gap-2">
           {hasActiveSub && (
@@ -144,7 +141,7 @@ export default async function CustomerDetailPage({ params }: { params: Promise<{
                   <div className="text-sm text-gray-500 space-y-0.5">
                     <p>Честота: {sub.frequency === 'monthly' ? 'Месечна' : sub.frequency === 'seasonal' ? 'Сезонна' : sub.frequency}</p>
                     <p>Цена: {formatPrice(sub.current_price_eur)}</p>
-                    <p>Начало: {formatDate(sub.started_at)}</p>
+                    <p>Начало: {formatDateTimeShort(sub.started_at)}</p>
                     {sub.default_address_id && (
                       <p className="text-xs text-gray-400">📍 Свързан адрес</p>
                     )}
@@ -196,7 +193,7 @@ export default async function CustomerDetailPage({ params }: { params: Promise<{
                             {formatPrice(order.final_price_eur)}
                           </td>
                           <td className="px-4 py-3 text-gray-500">
-                            {formatDate(order.created_at)}
+                            {formatDateTimeShort(order.created_at)}
                           </td>
                         </tr>
                       );

--- a/app/admin/feedback/page.tsx
+++ b/app/admin/feedback/page.tsx
@@ -1,6 +1,7 @@
 import { requireStaff } from '@/lib/auth';
 import { getFeedbackFormsPaginated, getResponseCountByForm } from '@/lib/data/feedback-forms';
 import { AdminHelpLink } from '@/components/admin/AdminHelpLink';
+import { formatDateShort } from '@/lib/utils/date';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 
@@ -141,7 +142,7 @@ export default async function FeedbackFormsPage({ searchParams }: FeedbackPagePr
                     {responseCounts[i]}
                   </td>
                   <td className="px-4 py-3 text-gray-500">
-                    {new Date(form.created_at).toLocaleDateString('bg-BG')}
+                    {formatDateShort(form.created_at)}
                   </td>
                   <td className="px-4 py-3">
                     <Link

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import { requireStaff } from '@/lib/auth';
 import { getOrdersCount, getSubscriptionsCount, getSubscriptionMRR, getSiteConfig, getEurToBgnRate } from '@/lib/data';
 import { getStaffCount } from '@/lib/data/customers';
+import { formatDateTimeShort } from '@/lib/utils/date';
 
 export const metadata = {
   title: 'Табло | FitFlow Admin',
@@ -74,7 +75,7 @@ export default async function AdminDashboard() {
             <p className="text-gray-500">
               Последно изпълнение:{' '}
               <span className="font-medium text-gray-700">
-                {new Date(cronLastRun).toLocaleString('bg-BG', { timeZone: 'Europe/Sofia' })}
+                {formatDateTimeShort(cronLastRun)}
               </span>
             </p>
             {parsedCronResult && !parsedCronResult.error && (

--- a/app/admin/promo/page.tsx
+++ b/app/admin/promo/page.tsx
@@ -4,6 +4,7 @@ import type { PromoCodeFilters, PromoStatus } from '@/lib/data/promo';
 import Link from 'next/link';
 import PromoActions from '@/components/admin/PromoActions';
 import { AdminHelpLink } from '@/components/admin/AdminHelpLink';
+import { formatDateShort } from '@/lib/utils/date';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -59,11 +60,7 @@ function StatusBadge({ status }: { status: PromoStatus }) {
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '—';
-  return new Date(dateStr).toLocaleDateString('bg-BG', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  });
+  return formatDateShort(dateStr);
 }
 
 export default async function PromoPage({ searchParams }: PromoPageProps) {

--- a/app/admin/staff/page.tsx
+++ b/app/admin/staff/page.tsx
@@ -2,6 +2,7 @@ import { requireStaff } from '@/lib/auth';
 import { STAFF_MANAGEMENT_ROLES } from '@/lib/auth/permissions';
 import { supabaseAdmin } from '@/lib/supabase/admin';
 import { AdminHelpLink } from '@/components/admin/AdminHelpLink';
+import { formatDateShort } from '@/lib/utils/date';
 import Link from 'next/link';
 
 export const metadata = {
@@ -51,7 +52,7 @@ export default async function StaffListPage() {
                 <td className="py-3 px-4">{member.full_name}</td>
                 <td className="py-3 px-4 capitalize">{member.staff_role?.replace('_', ' ')}</td>
                 <td className="py-3 px-4 text-sm text-gray-500">
-                  {new Date(member.created_at).toLocaleDateString('bg-BG')}
+                  {formatDateShort(member.created_at)}
                 </td>
               </tr>
             ))}

--- a/app/order/track/page.tsx
+++ b/app/order/track/page.tsx
@@ -9,6 +9,7 @@ import Footer from '@/components/Footer';
 import { ORDER_STATUS_COLORS, STATUS_BG_COLORS, formatShippingAddress } from '@/lib/order';
 import type { OrderStatus, ShippingAddressSnapshot } from '@/lib/supabase/types';
 import { formatPriceDual } from '@/lib/catalog';
+import { formatDateLong } from '@/lib/utils/date';
 import { StatusTimeline } from '@/components/account/StatusTimeline';
 import type { StatusHistoryEntry } from '@/components/account/StatusTimeline';
 
@@ -183,11 +184,7 @@ function OrderTrackingContent() {
             <div>
               <dt className="text-gray-500 mb-1">Дата</dt>
               <dd className="font-semibold text-gray-900">
-                {new Date(order.createdAt).toLocaleDateString('bg-BG', {
-                  day: 'numeric',
-                  month: 'long',
-                  year: 'numeric',
-                })}
+                {formatDateLong(order.createdAt)}
               </dd>
             </div>
           </dl>

--- a/components/account/OrdersList.tsx
+++ b/components/account/OrdersList.tsx
@@ -15,6 +15,7 @@ import {
   getStatusIcon,
 } from '@/lib/order';
 import { formatPriceDual } from '@/lib/catalog';
+import { formatDateShort } from '@/lib/utils/date';
 import type {
   OrderRow,
   Preorder,
@@ -122,14 +123,6 @@ const PAGE_SIZE = 15;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('bg-BG', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  });
-}
 
 function dualPrice(eur: number, rate: number): string {
   return formatPriceDual(eur, eur * rate);
@@ -443,7 +436,7 @@ export function OrdersList({
                 {formatOrderNumber(order.order_number)}
               </span>
               <span className="ml-2 text-sm text-gray-400">
-                {formatDate(order.created_at)}
+                {formatDateShort(order.created_at)}
               </span>
             </div>
 
@@ -534,7 +527,7 @@ export function OrdersList({
                         (h) => h.to_status === step,
                       );
                       const tooltipText = historyEntry
-                        ? `${ORDER_STATUS_LABELS[step]} - ${new Date(historyEntry.created_at).toLocaleDateString('bg-BG', { day: '2-digit', month: '2-digit', year: 'numeric' })}`
+                        ? `${ORDER_STATUS_LABELS[step]} - ${formatDateShort(historyEntry.created_at)}`
                         : ORDER_STATUS_LABELS[step];
 
                       return (
@@ -558,11 +551,7 @@ export function OrdersList({
                 {/* Last update date */}
                 {lastEntry && (
                   <span>
-                    {new Date(lastEntry.created_at).toLocaleDateString('bg-BG', {
-                      day: '2-digit',
-                      month: '2-digit',
-                      year: 'numeric',
-                    })}
+                    {formatDateShort(lastEntry.created_at)}
                   </span>
                 )}
               </div>
@@ -624,7 +613,7 @@ export function OrdersList({
               Предварителна поръчка
             </span>
             <span className="ml-2 text-sm text-gray-400">
-              {formatDate(preorder.created_at)}
+                {formatDateShort(preorder.created_at)}
             </span>
           </div>
 

--- a/components/account/StatusTimeline.tsx
+++ b/components/account/StatusTimeline.tsx
@@ -7,30 +7,7 @@ import {
   STATUS_BG_COLORS,
 } from '@/lib/order';
 import type { OrderStatus } from '@/lib/supabase/types';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function formatRelativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diffMs = now - then;
-  const diffMinutes = Math.floor(diffMs / 60_000);
-
-  if (diffMinutes < 1) return 'току-що';
-  if (diffMinutes < 60) return `преди ${diffMinutes} мин.`;
-
-  const diffHours = Math.floor(diffMinutes / 60);
-  if (diffHours < 24) return `преди ${diffHours} ч.`;
-
-  const diffDays = Math.floor(diffHours / 24);
-  if (diffDays === 1) return 'преди 1 ден';
-  if (diffDays <= 30) return `преди ${diffDays} дни`;
-  if (diffDays <= 364) return `преди ${Math.floor(diffDays / 30)} мес.`;
-
-  return `преди ${Math.floor(diffDays / 365)} г.`;
-}
+import { formatDateTimeLong, formatRelative } from '@/lib/utils/date';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -107,16 +84,10 @@ export function StatusTimeline({ statusHistory, currentStatus }: StatusTimelineP
                 {ORDER_STATUS_LABELS[entry.toStatus]}
               </p>
               <p className="text-xs text-gray-500 mt-0.5">
-                {new Date(entry.createdAt).toLocaleDateString('bg-BG', {
-                  day: 'numeric',
-                  month: 'long',
-                  year: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })}
+                {formatDateTimeLong(entry.createdAt)}
                 <span className="text-gray-400">
                   {' · '}
-                  {formatRelativeTime(entry.createdAt)}
+                  {formatRelative(entry.createdAt)}
                 </span>
               </p>
               {entry.notes && (

--- a/components/account/SubscriptionCard.tsx
+++ b/components/account/SubscriptionCard.tsx
@@ -11,6 +11,7 @@ import {
   formatSubscriptionSummary,
 } from '@/lib/subscription';
 import { formatDeliveryDate } from '@/lib/delivery';
+import { formatDateShort } from '@/lib/utils/date';
 import { formatPriceDual, eurToBgnSync } from '@/lib/catalog';
 import type { AddressRow } from '@/lib/supabase/types';
 import type { PricesMap, CatalogData, PriceDisplayInfo } from '@/lib/catalog';
@@ -331,7 +332,7 @@ export default function SubscriptionCard({
                 {pastOrders.slice(0, 2).map((order) => (
                   <li key={order.id} className="flex items-center justify-between text-sm">
                     <span className="text-gray-600">
-                      #{order.order_number} · {new Date(order.created_at).toLocaleDateString('bg-BG')} · {order.status}
+                      #{order.order_number} · {formatDateShort(order.created_at)} · {order.status}
                     </span>
                     <Link
                       href={`/account/orders/${encodeURIComponent(order.order_number)}`}
@@ -364,7 +365,7 @@ export default function SubscriptionCard({
                       <div>
                         <span className="font-medium text-gray-900">#{order.order_number}</span>
                         <span className="text-gray-400 ml-2">
-                          {new Date(order.created_at).toLocaleDateString('bg-BG')}
+                          {formatDateShort(order.created_at)}
                         </span>
                       </div>
                       <Link

--- a/components/account/SubscriptionTimeline.tsx
+++ b/components/account/SubscriptionTimeline.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { formatDateCompact } from '@/lib/utils/date';
+
 interface TimelineEvent {
   key: string;
   label: string;
@@ -18,20 +20,12 @@ interface SubscriptionTimelineProps {
   loadingOrders: boolean;
 }
 
-function shortDate(iso: string): string {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return iso;
-  const dd = String(d.getDate()).padStart(2, '0');
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
-  return `${dd}.${mm}`;
-}
-
 function buildEvents(props: SubscriptionTimelineProps): TimelineEvent[] {
   const { createdAt, status, pastOrders, pausedAt, cancelledAt, nextDeliveryDate } = props;
   const events: TimelineEvent[] = [];
 
   // 1 - Created
-  events.push({ key: 'created', label: 'Създ.', date: shortDate(createdAt), type: 'completed' });
+  events.push({ key: 'created', label: 'Създ.', date: formatDateCompact(createdAt), type: 'completed' });
 
   // 2 - Delivered cycles from past orders
   if (pastOrders && pastOrders.length > 0) {
@@ -45,7 +39,7 @@ function buildEvents(props: SubscriptionTimelineProps): TimelineEvent[] {
         events.push({
           key: `order-${o.order_number}`,
           label: `Дост. ${i + 1}`,
-          date: shortDate(o.created_at),
+          date: formatDateCompact(o.created_at),
           type: 'completed',
         });
       });
@@ -62,7 +56,7 @@ function buildEvents(props: SubscriptionTimelineProps): TimelineEvent[] {
         events.push({
           key: `order-${o.order_number}`,
           label: `Дост. ${skipped + i + 1}`,
-          date: shortDate(o.created_at),
+          date: formatDateCompact(o.created_at),
           type: 'completed',
         });
       });
@@ -71,17 +65,17 @@ function buildEvents(props: SubscriptionTimelineProps): TimelineEvent[] {
 
   // 3 - Paused
   if (pausedAt && status === 'paused') {
-    events.push({ key: 'paused', label: 'Пауза', date: shortDate(pausedAt), type: 'paused' });
+    events.push({ key: 'paused', label: 'Пауза', date: formatDateCompact(pausedAt), type: 'paused' });
   }
 
   // 4 - Cancelled
   if (cancelledAt && (status === 'cancelled' || status === 'expired')) {
-    events.push({ key: 'cancelled', label: 'Отказан', date: shortDate(cancelledAt), type: 'cancelled' });
+    events.push({ key: 'cancelled', label: 'Отказан', date: formatDateCompact(cancelledAt), type: 'cancelled' });
   }
 
   // 5 - Next delivery (future)
   if (status === 'active' && nextDeliveryDate) {
-    events.push({ key: 'next', label: 'Следв.', date: shortDate(nextDeliveryDate), type: 'future' });
+    events.push({ key: 'next', label: 'Следв.', date: formatDateCompact(nextDeliveryDate), type: 'future' });
   }
 
   return events;

--- a/components/admin/CampaignDetailView.tsx
+++ b/components/admin/CampaignDetailView.tsx
@@ -6,6 +6,7 @@ import CampaignStatusBadge from './CampaignStatusBadge';
 import CampaignTypeBadge from './CampaignTypeBadge';
 import CampaignHistoryTimeline from './CampaignHistoryTimeline';
 import SendTestEmailModal from './SendTestEmailModal';
+import { formatDateTimeShort } from '@/lib/utils/date';
 import type {
   EmailCampaignRow,
   EmailCampaignHistoryRow,
@@ -600,7 +601,7 @@ export default function CampaignDetailView({
                         </td>
                         <td className="px-4 py-3 text-gray-500 text-xs">
                           {r.sent_at
-                            ? new Date(r.sent_at).toLocaleString('bg-BG')
+                            ? formatDateTimeShort(r.sent_at)
                             : '—'}
                         </td>
                         <td className="px-4 py-3 text-red-500 text-xs max-w-[200px] truncate" title={r.error ?? ''}>

--- a/components/admin/CampaignHistoryTimeline.tsx
+++ b/components/admin/CampaignHistoryTimeline.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import type { EmailCampaignHistoryRow } from '@/lib/supabase/types';
+import { formatDateTimeShort, formatRelative } from '@/lib/utils/date';
 
 interface CampaignHistoryTimelineProps {
   history: EmailCampaignHistoryRow[];
@@ -19,32 +20,6 @@ const ACTION_CONFIG: Record<string, { icon: string; label: string; color: string
   'send-test': { icon: '🧪', label: 'Тестов имейл', color: 'border-purple-400' },
   deleted: { icon: '🗑️', label: 'Изтрита', color: 'border-red-400' },
 };
-
-function formatTimestamp(dateStr: string): string {
-  const d = new Date(dateStr);
-  return d.toLocaleString('bg-BG', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
-function relativeTimestamp(dateStr: string): string {
-  const now = Date.now();
-  const date = new Date(dateStr).getTime();
-  const diff = now - date;
-  const minutes = Math.floor(diff / 60_000);
-  const hours = Math.floor(diff / 3_600_000);
-  const days = Math.floor(diff / 86_400_000);
-
-  if (minutes < 1) return 'току-що';
-  if (minutes < 60) return `преди ${minutes} мин`;
-  if (hours < 24) return `преди ${hours} ч`;
-  if (days < 30) return `преди ${days} дни`;
-  return formatTimestamp(dateStr);
-}
 
 export default function CampaignHistoryTimeline({ history }: CampaignHistoryTimelineProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -90,9 +65,9 @@ export default function CampaignHistoryTimeline({ history }: CampaignHistoryTime
                   </span>
                   <span
                     className="text-xs text-gray-400"
-                    title={formatTimestamp(entry.created_at)}
+                    title={formatDateTimeShort(entry.created_at)}
                   >
-                    {relativeTimestamp(entry.created_at)}
+                    {formatRelative(entry.created_at)}
                   </span>
                 </div>
 

--- a/components/admin/CustomersTable.tsx
+++ b/components/admin/CustomersTable.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import type { CustomerWithStats } from '@/lib/supabase/types';
+import { formatDateShort } from '@/lib/utils/date';
 
 /** Mask a full name: show first character + '***' */
 function maskName(name: string): string {
@@ -159,15 +160,13 @@ export function CustomersTable({
                   {/* Last order date */}
                   <td className="px-4 py-3 text-sm text-gray-500">
                     {customer.last_order_date
-                      ? new Date(
-                          customer.last_order_date,
-                        ).toLocaleDateString('bg-BG')
+                      ? formatDateShort(customer.last_order_date)
                       : '—'}
                   </td>
 
                   {/* Registration date */}
                   <td className="px-4 py-3 text-sm text-gray-500">
-                    {new Date(customer.created_at).toLocaleDateString('bg-BG')}
+                    {formatDateShort(customer.created_at)}
                   </td>
                 </tr>
               ))}

--- a/components/admin/CycleDetailView.tsx
+++ b/components/admin/CycleDetailView.tsx
@@ -8,6 +8,7 @@ import type {
   DeliveryCycleItemRow,
   DeliveryCycleDerivedState,
 } from '@/lib/delivery';
+import { formatDateShort } from '@/lib/utils/date';
 
 // ============================================================================
 // Constants
@@ -428,7 +429,7 @@ export function CycleDetailView({
               Разкрито
               {cycle.revealed_at && (
                 <span className="text-gray-400 font-normal ml-1">
-                  ({new Date(cycle.revealed_at).toLocaleDateString('bg-BG')})
+                  ({formatDateShort(cycle.revealed_at)})
                 </span>
               )}
             </span>

--- a/components/admin/DeliverySettingsForm.tsx
+++ b/components/admin/DeliverySettingsForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import type { DeliveryConfig } from '@/lib/delivery';
+import { formatDateShort } from '@/lib/utils/date';
 
 interface DeliverySettingsFormProps {
   config: DeliveryConfig;
@@ -21,7 +22,7 @@ function calculatePreviewDate(deliveryDay: number, firstDate: string | null): st
     if (y && m && d) {
       const first = new Date(y, m - 1, d);
       if (first >= today) {
-        return formatDate(first);
+        return formatDateShort(toISODate(first));
       }
     }
   }
@@ -35,7 +36,7 @@ function calculatePreviewDate(deliveryDay: number, firstDate: string | null): st
   const thisMonth = new Date(year, month, clampedDay);
 
   if (thisMonth > today) {
-    return formatDate(thisMonth);
+    return formatDateShort(toISODate(thisMonth));
   }
 
   // Next month
@@ -43,14 +44,14 @@ function calculatePreviewDate(deliveryDay: number, firstDate: string | null): st
   const nextYear = month === 11 ? year + 1 : year;
   const nextLastDay = new Date(nextYear, nextMonth + 1, 0).getDate();
   const nextClamped = Math.min(deliveryDay, nextLastDay);
-  return formatDate(new Date(nextYear, nextMonth, nextClamped));
+  return formatDateShort(toISODate(new Date(nextYear, nextMonth, nextClamped)));
 }
 
-function formatDate(d: Date): string {
-  const dd = String(d.getDate()).padStart(2, '0');
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
+function toISODate(d: Date): string {
   const yyyy = d.getFullYear();
-  return `${dd}.${mm}.${yyyy}`;
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
 }
 
 export function DeliverySettingsForm({ config }: DeliverySettingsFormProps) {

--- a/components/admin/EmailHealthCard.tsx
+++ b/components/admin/EmailHealthCard.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { formatDateTimeShort } from '@/lib/utils/date';
 
 interface EmailSystemHealth {
   status: 'healthy' | 'warning' | 'error';
@@ -164,7 +165,7 @@ export default function EmailHealthCard() {
       {/* Webhook warning */}
       {webhookStale && (
         <div className="mt-3 text-xs text-yellow-700 bg-yellow-100 rounded-md px-3 py-2">
-          ⚠️ Последен webhook преди повече от 1 час ({health.lastWebhookAt ? new Date(health.lastWebhookAt).toLocaleString('bg-BG') : '—'}).
+          ⚠️ Последен webhook преди повече от 1 час ({health.lastWebhookAt ? formatDateTimeShort(health.lastWebhookAt) : '—'}).
           Проверете Brevo webhook настройките.
         </div>
       )}

--- a/components/admin/EmailLogTable.tsx
+++ b/components/admin/EmailLogTable.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useEffect, useCallback, useTransition } from 'react';
 import type { EmailSendLogRow, EmailLogStatusEnum } from '@/lib/supabase/types';
+import { formatDateTimeShort } from '@/lib/utils/date';
 
 const PER_PAGE = 50;
 
@@ -27,14 +28,7 @@ function maskEmail(email: string): string {
 /** Format timestamp for display */
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '—';
-  const d = new Date(dateStr);
-  return d.toLocaleDateString('bg-BG', {
-    day: '2-digit',
-    month: '2-digit',
-    year: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  return formatDateTimeShort(dateStr);
 }
 
 /** Truncate text to N chars */

--- a/components/admin/FeedbackResponsesTable.tsx
+++ b/components/admin/FeedbackResponsesTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FeedbackResponseRow, FeedbackFieldDefinition } from '@/lib/supabase/types';
+import { formatDateTimeShort } from '@/lib/utils/date';
 
 interface Props {
   responses: FeedbackResponseRow[];
@@ -57,7 +58,7 @@ export default function FeedbackResponsesTable({ responses, fields }: Props) {
                 </td>
               ))}
               <td className="px-3 py-2 text-gray-500 text-xs whitespace-nowrap">
-                {new Date(response.created_at).toLocaleString('bg-BG')}
+                {formatDateTimeShort(response.created_at)}
               </td>
             </tr>
           ))}

--- a/components/admin/LegacyPreordersTable.tsx
+++ b/components/admin/LegacyPreordersTable.tsx
@@ -2,21 +2,13 @@
 
 import { useState } from 'react';
 import type { Preorder, PreorderConversionStatus } from '@/lib/supabase/types';
+import { formatDateTimeShort } from '@/lib/utils/date';
 
 interface LegacyPreordersTableProps {
   preorders: Array<Preorder & { converted_order_number?: string }>;
   boxTypeNames: Record<string, string>;
   conversionStatusLabels: Record<PreorderConversionStatus, string>;
   conversionStatusColors: Record<PreorderConversionStatus, string>;
-}
-
-function formatDate(iso: string) {
-  const d = new Date(iso);
-  return d.toLocaleDateString('bg-BG', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  });
 }
 
 export function LegacyPreordersTable({
@@ -98,7 +90,7 @@ export function LegacyPreordersTable({
 
               {/* Date */}
               <td className="py-3 px-4 text-sm text-gray-500">
-                {formatDate(preorder.created_at)}
+                {formatDateTimeShort(preorder.created_at)}
               </td>
             </tr>
           ))}

--- a/components/admin/OrdersTable.tsx
+++ b/components/admin/OrdersTable.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/order/format';
 import { formatShippingAddressOneLine, ALLOWED_TRANSITIONS } from '@/lib/order';
 import { formatPriceDual, eurToBgnSync } from '@/lib/catalog';
+import { formatDateTimeShort } from '@/lib/utils/date';
 import OrderPromoAction from './OrderPromoAction';
 
 // ============================================================================
@@ -65,30 +66,6 @@ const FIELD_LABELS: Record<string, string> = {
   dietary_other: 'Друго ограничение',
   additional_notes: 'Допълнителни бележки',
 };
-
-// ============================================================================
-// Date formatting
-// ============================================================================
-
-function formatDate(iso: string) {
-  const d = new Date(iso);
-  return d.toLocaleDateString('bg-BG', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  });
-}
-
-function formatDateTime(iso: string) {
-  const d = new Date(iso);
-  return d.toLocaleString('bg-BG', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
 
 // ============================================================================
 // Delivery helper
@@ -400,7 +377,7 @@ export function OrdersTable({
                         <span
                           className="ml-2 text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700"
                           title={`Последно напомняне: ${reminderCounts[order.id].lastSentAt
-                            ? new Date(reminderCounts[order.id].lastSentAt!).toLocaleDateString('bg-BG')
+                            ? formatDateTimeShort(reminderCounts[order.id].lastSentAt!)
                             : '—'}`}
                         >
                           📧 {reminderCounts[order.id].count}/3 напомняния
@@ -454,7 +431,7 @@ export function OrdersTable({
 
                     {/* Date */}
                     <td className="py-3 px-4 text-sm text-gray-500">
-                      {formatDate(order.created_at)}
+                      {formatDateTimeShort(order.created_at)}
                     </td>
 
                     {/* Actions */}
@@ -832,7 +809,7 @@ function OrderRowDetail({
             {history.map(entry => (
               <li key={entry.id} className="relative">
                 <div className="absolute -left-[21px] top-1 w-2.5 h-2.5 rounded-full bg-[var(--color-brand-navy)]" />
-                <p className="text-xs text-gray-500">{formatDateTime(entry.created_at)}</p>
+                <p className="text-xs text-gray-500">{formatDateTimeShort(entry.created_at)}</p>
                 <p className="text-sm">
                   {entry.from_status ? (
                     <>
@@ -864,7 +841,7 @@ function OrderRowDetail({
             </p>
             {reminderCounts[order.id].lastSentAt && (
               <p className="text-amber-600 text-xs mt-1">
-                Последно: {new Date(reminderCounts[order.id].lastSentAt!).toLocaleString('bg-BG')}
+                Последно: {formatDateTimeShort(reminderCounts[order.id].lastSentAt!)}
               </p>
             )}
             {reminderCounts[order.id].count >= 3 && (

--- a/components/admin/SubscriptionDetailView.tsx
+++ b/components/admin/SubscriptionDetailView.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import type { SubscriptionRow, SubscriptionDerivedState, SubscriptionHistoryRow, SubscriptionAction } from '@/lib/subscription';
 import { SUBSCRIPTION_STATUS_LABELS, SUBSCRIPTION_STATUS_COLORS, FREQUENCY_LABELS } from '@/lib/subscription';
-import { formatDeliveryDate } from '@/lib/delivery';
+import { formatDateTimeShort } from '@/lib/utils/date';
 import { formatPriceDual, eurToBgnSync } from '@/lib/catalog';
 import type { OrderRow, AddressRow } from '@/lib/supabase/types';
 
@@ -225,17 +225,7 @@ export function SubscriptionDetailView({
   }
 
   function formatDateTime(iso: string): string {
-    try {
-      return new Date(iso).toLocaleString('bg-BG', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      });
-    } catch {
-      return iso;
-    }
+    return formatDateTimeShort(iso);
   }
 
   // ============================================================================
@@ -329,7 +319,7 @@ export function SubscriptionDetailView({
               value={<span className="text-gray-400 text-sm">Няма</span>}
             />
           )}
-          <InfoItem label="Стартиран" value={formatDeliveryDate(subscription.started_at)} />
+          <InfoItem label="Стартиран" value={formatDateTimeShort(subscription.started_at)} />
           <InfoItem
             label="Адрес"
             value={
@@ -732,7 +722,7 @@ export function SubscriptionDetailView({
                       {order.final_price_eur != null ? formatPriceDual(Number(order.final_price_eur), eurToBgnSync(Number(order.final_price_eur), eurToBgnRate)) : '—'}
                     </td>
                     <td className="px-4 py-3 text-gray-500">
-                      {formatDeliveryDate(order.created_at)}
+                      {formatDateTimeShort(order.created_at)}
                     </td>
                   </tr>
                 ))}

--- a/components/admin/SubscriptionsTable.tsx
+++ b/components/admin/SubscriptionsTable.tsx
@@ -7,7 +7,7 @@ import {
   SUBSCRIPTION_STATUS_COLORS,
   FREQUENCY_LABELS,
 } from '@/lib/subscription';
-import { formatDeliveryDate } from '@/lib/delivery';
+import { formatDateTimeShort } from '@/lib/utils/date';
 import { formatPriceDual, eurToBgnSync } from '@/lib/catalog';
 
 interface SubscriptionsTableProps {
@@ -102,7 +102,7 @@ export function SubscriptionsTable({
 
                   {/* Created */}
                   <td className="px-4 py-3 text-gray-500">
-                    {formatDeliveryDate(sub.created_at)}
+                    {formatDateTimeShort(sub.created_at)}
                   </td>
 
                   {/* Actions */}

--- a/components/admin/UnsubscribesTable.tsx
+++ b/components/admin/UnsubscribesTable.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import type { EmailUnsubscribeRow } from '@/lib/supabase/types';
+import { formatDateTimeShort } from '@/lib/utils/date';
 
 interface UnsubscribesTableProps {
   unsubscribes: EmailUnsubscribeRow[];
@@ -155,7 +156,7 @@ export default function UnsubscribesTable({
                         {unsub.reason ?? '—'}
                       </td>
                       <td className="px-4 py-3 text-gray-500 text-xs">
-                        {new Date(unsub.unsubscribed_at).toLocaleString('bg-BG')}
+                        {formatDateTimeShort(unsub.unsubscribed_at)}
                       </td>
                       <td className="px-4 py-3">
                         <button

--- a/lib/delivery/derived.ts
+++ b/lib/delivery/derived.ts
@@ -247,8 +247,10 @@ export function computeCycleState(
  */
 function parseISODate(dateStr: string): Date | null {
   if (!dateStr) return null;
+  // Strip any time / timezone portion so we only parse the date part
+  const datePart = dateStr.includes('T') ? dateStr.split('T')[0] : dateStr;
   // Split to avoid timezone offset issues with `new Date('YYYY-MM-DD')`
-  const [y, m, d] = dateStr.split('-').map(Number);
+  const [y, m, d] = datePart.split('-').map(Number);
   if (!y || !m || !d) return null;
   return new Date(y, m - 1, d);
 }

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -13,6 +13,7 @@ import {
   formatSavings,
 } from '@/lib/catalog';
 import { escapeHtml } from '@/lib/utils/sanitize';
+import { formatDateShort } from '@/lib/utils/date';
 import { EMAIL } from './constants';
 import { wrapInEmailLayout, emailCtaButton, emailContactLine } from './layout';
 
@@ -32,12 +33,6 @@ function safeSavings(eur: number | null | undefined, bgn: number | null | undefi
   if (eur == null || eur <= 0) return '';
   if (bgn != null && bgn > 0) return formatSavings(eur, bgn);
   return `Спестяваш ${formatPriceEur(eur)}`;
-}
-
-/** Format an ISO date string in Bulgarian DD.MM.YYYY format */
-function formatDateBg(isoDate: string): string {
-  const d = new Date(isoDate);
-  return d.toLocaleDateString('bg-BG', { day: '2-digit', month: '2-digit', year: 'numeric' });
 }
 
 // ============================================================================
@@ -563,7 +558,7 @@ export function generateDeliveryReminderEmail(data: DeliveryReminderEmailData): 
 
   const safeName = escapeHtml(customerName);
   const safeOrder = escapeHtml(orderNumber);
-  const shippedFormatted = formatDateBg(shippedAt);
+  const shippedFormatted = formatDateShort(shippedAt);
   const safeAutoDate = escapeHtml(autoConfirmDate);
 
   let escalationHtml = '';
@@ -613,7 +608,7 @@ export function generateDeliveryAutoConfirmedEmail(data: DeliveryAutoConfirmedEm
 
   const safeName = escapeHtml(customerName);
   const safeOrder = escapeHtml(orderNumber);
-  const confirmedFormatted = formatDateBg(confirmedAt);
+  const confirmedFormatted = formatDateShort(confirmedAt);
 
   const bodyHtml = `
   <h2 style="color: ${EMAIL.colors.textHeading}; margin-top: 0; font-size: 24px;">

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared date/time formatting utilities (Bulgarian locale).
+ *
+ * Import from '@/lib/utils/date' everywhere instead of defining local helpers.
+ */
+
+// ---------------------------------------------------------------------------
+// Short numeric formats
+// ---------------------------------------------------------------------------
+
+/** DD.MM.YYYY — e.g. `08.03.2026` */
+export function formatDateShort(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('bg-BG', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+/** DD.MM.YYYY, HH:mm — e.g. `08.03.2026, 14:30` */
+export function formatDateTimeShort(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString('bg-BG', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/** DD.MM — e.g. `08.03` (compact, no year) */
+export function formatDateCompact(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('bg-BG', {
+    day: '2-digit',
+    month: '2-digit',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Long (human-friendly) formats
+// ---------------------------------------------------------------------------
+
+/** 1 март 2026 г. */
+export function formatDateLong(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('bg-BG', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+/** 1 март 2026 г., 14:30 */
+export function formatDateTimeLong(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('bg-BG', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Relative time
+// ---------------------------------------------------------------------------
+
+/** преди X мин. / ч. / дни — falls back to formatDateTimeShort after 30 days */
+export function formatRelative(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  if (isNaN(then)) return iso;
+
+  const diffMs = now - then;
+  const minutes = Math.floor(diffMs / 60_000);
+
+  if (minutes < 1) return 'току-що';
+  if (minutes < 60) return `преди ${minutes} мин.`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `преди ${hours} ч.`;
+
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'преди 1 ден';
+  if (days <= 30) return `преди ${days} дни`;
+
+  return formatDateTimeShort(iso);
+}


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Issue #197 

---

## Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
Replaces 18 duplicated date/time formatting functions scattered across ~25 files with a single shared module `/lib/util/date.ts`, providing 6 canonical formatters. This eliminates inconsistent output between pages (bare locale D.MM.YYYY г. vs explicit DD.MM.YYYY, 2-digit vs 4-digit year, datetime with/without seconds), fixes a bug where raw ISO timestamps were rendered on admin subscription pages because `parseISODate` couldn't handle full timestamps, and upgrades all admin order/subscription date displays to include time for better operational visibility.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
