### PR TITLE
[DEV] Inline OTP authentication for subscription order flow

### DIFF
--- a/.changeset/inline-otp-auth.md
+++ b/.changeset/inline-otp-auth.md
@@ -1,0 +1,5 @@
+---
+"fitflow": minor
+---
+
+Replace redirect-based registration/login on the subscription order flow (step 3) with inline OTP email verification. Guests now verify their email with a 6-digit code without leaving the order page, preserving all order preferences and preventing phantom orders from mistyped emails.

--- a/app/admin/campaigns/page.tsx
+++ b/app/admin/campaigns/page.tsx
@@ -25,22 +25,6 @@ interface CampaignsPageProps {
   }>;
 }
 
-/** Relative date formatter in Bulgarian */
-function relativeDate(dateStr: string): string {
-  const now = Date.now();
-  const date = new Date(dateStr).getTime();
-  const diff = now - date;
-  const minutes = Math.floor(diff / 60_000);
-  const hours = Math.floor(diff / 3_600_000);
-  const days = Math.floor(diff / 86_400_000);
-
-  if (minutes < 1) return 'току-що';
-  if (minutes < 60) return `преди ${minutes} мин`;
-  if (hours < 24) return `преди ${hours} ч`;
-  if (days < 30) return `преди ${days} дни`;
-  return new Date(dateStr).toLocaleDateString('bg-BG');
-}
-
 const STATUS_OPTIONS: [EmailCampaignStatusEnum, string][] = [
   ['draft', 'Чернова'],
   ['scheduled', 'Планирана'],

--- a/app/api/auth/send-otp/route.ts
+++ b/app/api/auth/send-otp/route.ts
@@ -1,0 +1,125 @@
+/**
+ * Public API - Send OTP
+ *
+ * POST /api/auth/send-otp
+ *
+ * Generates a 6-digit OTP, stores its SHA-256 hash in the database,
+ * and sends the code to the provided email via Brevo.
+ * Used for inline registration and login during the order flow.
+ *
+ * Rate-limited: 5 requests/min per IP, 3 requests/min per email.
+ */
+
+import { NextResponse } from 'next/server';
+import { createHash, randomInt } from 'crypto';
+import { supabaseAdmin } from '@/lib/supabase/admin';
+import { isValidEmail } from '@/lib/catalog';
+import { checkRateLimit } from '@/lib/utils/rateLimit';
+import { sendEmail } from '@/lib/email/emailService';
+import { generateOtpVerificationEmail } from '@/lib/email/templates';
+
+const OTP_EXPIRY_SECONDS = 600; // 10 minutes
+
+function hashOtp(otp: string): string {
+  return createHash('sha256').update(otp).digest('hex');
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    // ---- Rate limiting ---------------------------------------------------
+    const ip = request.headers.get('x-forwarded-for') ?? 'unknown';
+
+    const withinIpLimit = await checkRateLimit(`send_otp_ip:${ip}`, 5, 60);
+    if (!withinIpLimit) {
+      return NextResponse.json(
+        { error: 'Твърде много опити. Моля, опитайте по-късно.' },
+        { status: 429 },
+      );
+    }
+
+    // ---- Parse & validate body -------------------------------------------
+    const body = await request.json();
+    const { email, name } = body as { email?: string; name?: string };
+
+    if (!email || typeof email !== 'string') {
+      return NextResponse.json(
+        { error: 'Полето email е задължително.' },
+        { status: 400 },
+      );
+    }
+
+    const normalizedEmail = email.trim().toLowerCase();
+
+    if (!isValidEmail(normalizedEmail)) {
+      return NextResponse.json(
+        { error: 'Невалиден email адрес.' },
+        { status: 400 },
+      );
+    }
+
+    // Per-email rate limit (prevents bombing a single address)
+    const withinEmailLimit = await checkRateLimit(`send_otp_email:${normalizedEmail}`, 3, 60);
+    if (!withinEmailLimit) {
+      return NextResponse.json(
+        { error: 'Твърде много опити за този имейл. Моля, опитайте по-късно.' },
+        { status: 429 },
+      );
+    }
+
+    // ---- Generate OTP ----------------------------------------------------
+    const otp = randomInt(100000, 999999).toString();
+    const otpHash = hashOtp(otp);
+    const expiresAt = new Date(Date.now() + OTP_EXPIRY_SECONDS * 1000).toISOString();
+
+    // ---- Store OTP hash (upsert - one active OTP per email) ---------------
+    const { error: dbError } = await supabaseAdmin
+      .from('email_otp_verifications')
+      .upsert(
+        {
+          email: normalizedEmail,
+          otp_hash: otpHash,
+          attempts: 0,
+          created_at: new Date().toISOString(),
+          expires_at: expiresAt,
+        },
+        { onConflict: 'email' },
+      );
+
+    if (dbError) {
+      console.error('[send-otp] DB upsert failed:', dbError);
+      return NextResponse.json(
+        { error: 'Възникна грешка. Моля, опитайте по-късно.' },
+        { status: 500 },
+      );
+    }
+
+    // ---- Send email via Brevo --------------------------------------------
+    const htmlContent = generateOtpVerificationEmail(otp, name?.trim() || undefined);
+
+    const emailResult = await sendEmail({
+      to: { email: normalizedEmail },
+      subject: 'Код за потвърждение – FitFlow',
+      htmlContent,
+      tags: ['otp-verification'],
+    });
+
+    if (!emailResult.success) {
+      console.error('[send-otp] Email send failed:', emailResult.error);
+      return NextResponse.json(
+        { error: 'Неуспешно изпращане на имейл. Моля, опитайте по-късно.' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      expiresInSeconds: OTP_EXPIRY_SECONDS,
+    });
+  } catch (err) {
+    console.error('[send-otp] Unexpected error:', err);
+    return NextResponse.json(
+      { error: 'Възникна грешка. Моля, опитайте по-късно.' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/auth/verify-otp/route.ts
+++ b/app/api/auth/verify-otp/route.ts
@@ -1,0 +1,213 @@
+/**
+ * Public API - Verify OTP
+ *
+ * POST /api/auth/verify-otp
+ *
+ * Verifies a 6-digit OTP against the stored hash.
+ * On success, either creates a new account (register) or finds the
+ * existing account (login), then returns a tokenHash for the client
+ * to establish a browser session via supabase.auth.verifyOtp().
+ *
+ * Rate-limited: 10 requests/min per IP.
+ */
+
+import { NextResponse } from 'next/server';
+import { createHash, timingSafeEqual } from 'crypto';
+import { supabaseAdmin } from '@/lib/supabase/admin';
+import { isValidEmail } from '@/lib/catalog';
+import { sanitizeInput } from '@/lib/utils/sanitize';
+import { checkRateLimit } from '@/lib/utils/rateLimit';
+import { getUserByEmail } from '@/lib/auth/get-user-by-email';
+import { syncNewUser } from '@/lib/email/contact-sync';
+
+function hashOtp(otp: string): string {
+  return createHash('sha256').update(otp).digest('hex');
+}
+
+function constantTimeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    // ---- Rate limiting ---------------------------------------------------
+    const ip = request.headers.get('x-forwarded-for') ?? 'unknown';
+    const withinLimit = await checkRateLimit(`verify_otp_ip:${ip}`, 10, 60);
+    if (!withinLimit) {
+      return NextResponse.json(
+        { error: 'Твърде много опити. Моля, опитайте по-късно.' },
+        { status: 429 },
+      );
+    }
+
+    // ---- Parse & validate body -------------------------------------------
+    const body = await request.json();
+    const { email, otp, fullName, intent } = body as {
+      email?: string;
+      otp?: string;
+      fullName?: string;
+      intent?: 'register' | 'login';
+    };
+
+    if (!email || typeof email !== 'string' || !isValidEmail(email)) {
+      return NextResponse.json({ error: 'Невалиден email адрес.' }, { status: 400 });
+    }
+
+    if (!otp || typeof otp !== 'string' || !/^\d{6}$/.test(otp)) {
+      return NextResponse.json({ error: 'Невалиден код.' }, { status: 400 });
+    }
+
+    if (!intent || !['register', 'login'].includes(intent)) {
+      return NextResponse.json({ error: 'Невалидна заявка.' }, { status: 400 });
+    }
+
+    const normalizedEmail = email.trim().toLowerCase();
+
+    // ---- Fetch OTP row ---------------------------------------------------
+    const { data: otpRow, error: fetchError } = await supabaseAdmin
+      .from('email_otp_verifications')
+      .select('otp_hash, attempts, expires_at')
+      .eq('email', normalizedEmail)
+      .maybeSingle();
+
+    if (fetchError) {
+      console.error('[verify-otp] DB fetch failed:', fetchError);
+      return NextResponse.json(
+        { error: 'Възникна грешка. Моля, опитайте по-късно.' },
+        { status: 500 },
+      );
+    }
+
+    if (!otpRow) {
+      return NextResponse.json(
+        { error: 'Кодът е изтекъл. Моля, заявете нов.' },
+        { status: 400 },
+      );
+    }
+
+    // Check expiry
+    if (new Date(otpRow.expires_at) <= new Date()) {
+      await supabaseAdmin.from('email_otp_verifications').delete().eq('email', normalizedEmail);
+      return NextResponse.json(
+        { error: 'Кодът е изтекъл. Моля, заявете нов.' },
+        { status: 400 },
+      );
+    }
+
+    // Check max attempts
+    if (otpRow.attempts >= 5) {
+      await supabaseAdmin.from('email_otp_verifications').delete().eq('email', normalizedEmail);
+      return NextResponse.json(
+        { error: 'Твърде много опити. Моля, заявете нов код.' },
+        { status: 400 },
+      );
+    }
+
+    // Increment attempts
+    await supabaseAdmin
+      .from('email_otp_verifications')
+      .update({ attempts: otpRow.attempts + 1 })
+      .eq('email', normalizedEmail);
+
+    // ---- Compare OTP hash ------------------------------------------------
+    const inputHash = hashOtp(otp);
+    if (!constantTimeCompare(inputHash, otpRow.otp_hash)) {
+      return NextResponse.json({ error: 'Невалиден код.' }, { status: 400 });
+    }
+
+    // ---- OTP valid → delete it (one-time use) ----------------------------
+    await supabaseAdmin.from('email_otp_verifications').delete().eq('email', normalizedEmail);
+
+    // ---- Branch: register or login ---------------------------------------
+    if (intent === 'register') {
+      // Validate fullName for registration
+      if (!fullName || typeof fullName !== 'string' || !fullName.trim()) {
+        return NextResponse.json({ error: 'Полето за име е задължително.' }, { status: 400 });
+      }
+
+      const sanitizedName = sanitizeInput(fullName.trim(), 100);
+      if (!sanitizedName) {
+        return NextResponse.json({ error: 'Полето за име е задължително.' }, { status: 400 });
+      }
+
+      // Check user doesn't already exist
+      const existingUser = await getUserByEmail(normalizedEmail);
+      if (existingUser) {
+        return NextResponse.json(
+          { error: 'Потребител с този имейл вече съществува. Моля, влезте.' },
+          { status: 409 },
+        );
+      }
+
+      // Create user (email_confirm: true since OTP already proved ownership)
+      const { error: createError } = await supabaseAdmin.auth.admin.createUser({
+        email: normalizedEmail,
+        email_confirm: true,
+        user_metadata: {
+          full_name: sanitizedName,
+          has_password: false,
+        },
+      });
+
+      if (createError) {
+        if (createError.message?.includes('already registered')) {
+          return NextResponse.json(
+            { error: 'Потребител с този имейл вече съществува. Моля, влезте.' },
+            { status: 409 },
+          );
+        }
+        console.error('[verify-otp] createUser failed:', createError);
+        return NextResponse.json(
+          { error: 'Възникна грешка. Моля, опитайте по-късно.' },
+          { status: 500 },
+        );
+      }
+
+      // Sync to Brevo (fire-and-forget)
+      const nameParts = sanitizedName.split(/\s+/);
+      syncNewUser({
+        email: normalizedEmail,
+        firstName: nameParts[0] ?? '',
+        lastName: nameParts.slice(1).join(' ') || undefined,
+      }).catch((err) => {
+        console.warn('[verify-otp] syncNewUser failed:', err);
+      });
+    } else {
+      // Login: verify user exists
+      const existingUser = await getUserByEmail(normalizedEmail);
+      if (!existingUser) {
+        return NextResponse.json(
+          { error: 'Не намерихме акаунт с този имейл.' },
+          { status: 404 },
+        );
+      }
+    }
+
+    // ---- Generate magic link token for session establishment --------------
+    const { data: linkData, error: linkError } =
+      await supabaseAdmin.auth.admin.generateLink({
+        type: 'magiclink',
+        email: normalizedEmail,
+      });
+
+    if (linkError || !linkData?.properties?.hashed_token) {
+      console.error('[verify-otp] generateLink failed:', linkError);
+      return NextResponse.json(
+        { error: 'Възникна грешка. Моля, опитайте по-късно.' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      tokenHash: linkData.properties.hashed_token,
+    });
+  } catch (err) {
+    console.error('[verify-otp] Unexpected error:', err);
+    return NextResponse.json(
+      { error: 'Възникна грешка. Моля, опитайте по-късно.' },
+      { status: 500 },
+    );
+  }
+}

--- a/components/order/InlineAuth.tsx
+++ b/components/order/InlineAuth.tsx
@@ -1,0 +1,456 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { createClient } from '@/lib/supabase/browser';
+import { isValidEmail } from '@/lib/catalog';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type AuthTab = 'register' | 'login';
+type AuthPhase = 'form' | 'otp' | 'done';
+
+interface InlineAuthProps {
+  onAuthenticated: () => void;
+  onBack: () => void;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export default function InlineAuth({ onAuthenticated, onBack }: InlineAuthProps) {
+  const [tab, setTab] = useState<AuthTab>('register');
+  const [phase, setPhase] = useState<AuthPhase>('form');
+
+  // Form fields
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+
+  // OTP fields
+  const [otpDigits, setOtpDigits] = useState<string[]>(['', '', '', '', '', '']);
+  const otpRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  // Timers & state
+  const [expiresAt, setExpiresAt] = useState<number>(0);
+  const [secondsLeft, setSecondsLeft] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+
+  // ------------------------------------------------------------------
+  // Countdown timer
+  // ------------------------------------------------------------------
+  useEffect(() => {
+    if (phase !== 'otp' || expiresAt === 0) return;
+
+    function tick() {
+      const remaining = Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000));
+      setSecondsLeft(remaining);
+    }
+
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [phase, expiresAt]);
+
+  // ------------------------------------------------------------------
+  // Tab switching resets to form phase
+  // ------------------------------------------------------------------
+  function switchTab(newTab: AuthTab) {
+    setTab(newTab);
+    setPhase('form');
+    setError(null);
+    setOtpDigits(['', '', '', '', '', '']);
+  }
+
+  // ------------------------------------------------------------------
+  // Send OTP
+  // ------------------------------------------------------------------
+  const handleSendOtp = useCallback(async () => {
+    setError(null);
+
+    // Client-side validation
+    if (tab === 'register' && !fullName.trim()) {
+      setError('Моля, въведете вашето име.');
+      return;
+    }
+
+    if (!email.trim() || !isValidEmail(email)) {
+      setError('Моля, въведете валиден имейл адрес.');
+      return;
+    }
+
+    setSending(true);
+
+    try {
+      const res = await fetch('/api/auth/send-otp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: email.trim().toLowerCase(),
+          name: tab === 'register' ? fullName.trim() : undefined,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error ?? 'Възникна грешка.');
+        return;
+      }
+
+      // Transition to OTP phase
+      setExpiresAt(Date.now() + (data.expiresInSeconds ?? 600) * 1000);
+      setOtpDigits(['', '', '', '', '', '']);
+      setPhase('otp');
+
+      // Focus first OTP input after render
+      setTimeout(() => otpRefs.current[0]?.focus(), 50);
+    } catch {
+      setError('Възникна грешка. Моля, опитайте по-късно.');
+    } finally {
+      setSending(false);
+    }
+  }, [email, fullName, tab]);
+
+  // ------------------------------------------------------------------
+  // Verify OTP
+  // ------------------------------------------------------------------
+  const handleVerifyOtp = useCallback(
+    async (code: string) => {
+      setError(null);
+      setVerifying(true);
+
+      try {
+        const res = await fetch('/api/auth/verify-otp', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: email.trim().toLowerCase(),
+            otp: code,
+            fullName: tab === 'register' ? fullName.trim() : undefined,
+            intent: tab,
+          }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          setError(data.error ?? 'Невалиден код.');
+          setOtpDigits(['', '', '', '', '', '']);
+          setTimeout(() => otpRefs.current[0]?.focus(), 50);
+          return;
+        }
+
+        // Establish browser session via Supabase client
+        const supabase = createClient();
+        const { error: authError } = await supabase.auth.verifyOtp({
+          token_hash: data.tokenHash,
+          type: 'magiclink',
+        });
+
+        if (authError) {
+          console.error('[InlineAuth] verifyOtp failed:', authError);
+          setError('Грешка при влизане. Моля, опитайте отново.');
+          return;
+        }
+
+        // Session established — AuthProvider will pick up the change
+        setPhase('done');
+        setTimeout(() => onAuthenticated(), 400);
+      } catch {
+        setError('Възникна грешка. Моля, опитайте по-късно.');
+      } finally {
+        setVerifying(false);
+      }
+    },
+    [email, fullName, tab, onAuthenticated],
+  );
+
+  // ------------------------------------------------------------------
+  // OTP input handlers
+  // ------------------------------------------------------------------
+  function handleOtpChange(index: number, value: string) {
+    // Accept only single digit
+    const digit = value.replace(/\D/g, '').slice(-1);
+    const next = [...otpDigits];
+    next[index] = digit;
+    setOtpDigits(next);
+
+    if (digit && index < 5) {
+      otpRefs.current[index + 1]?.focus();
+    }
+
+    // Auto-submit when all 6 digits are entered
+    if (digit && index === 5) {
+      const code = next.join('');
+      if (code.length === 6 && /^\d{6}$/.test(code)) {
+        handleVerifyOtp(code);
+      }
+    }
+  }
+
+  function handleOtpKeyDown(index: number, e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Backspace' && !otpDigits[index] && index > 0) {
+      otpRefs.current[index - 1]?.focus();
+    }
+  }
+
+  function handleOtpPaste(e: React.ClipboardEvent<HTMLInputElement>) {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, 6);
+    if (!pasted) return;
+
+    const next = [...otpDigits];
+    for (let i = 0; i < pasted.length; i++) {
+      next[i] = pasted[i];
+    }
+    setOtpDigits(next);
+
+    // Focus last filled input or first empty
+    const focusIndex = Math.min(pasted.length, 5);
+    otpRefs.current[focusIndex]?.focus();
+
+    // Auto-submit if all 6 digits pasted
+    if (pasted.length === 6) {
+      handleVerifyOtp(pasted);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Format countdown
+  // ------------------------------------------------------------------
+  function formatTime(secs: number): string {
+    const m = Math.floor(secs / 60);
+    const s = secs % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
+  const isExpired = phase === 'otp' && secondsLeft === 0;
+
+  // ==================================================================
+  // Render: Done phase
+  // ==================================================================
+  if (phase === 'done') {
+    return (
+      <div className="bg-white rounded-xl sm:rounded-2xl p-6 sm:p-8 shadow-lg text-center">
+        <div className="text-5xl mb-4">✅</div>
+        <h3 className="text-xl sm:text-2xl font-bold text-[var(--color-brand-navy)] mb-2">
+          Готово!
+        </h3>
+        <p className="text-sm text-gray-600">
+          {tab === 'register' ? 'Акаунтът е създаден.' : 'Влязохте успешно.'}
+        </p>
+      </div>
+    );
+  }
+
+  // ==================================================================
+  // Render: Form + OTP phases
+  // ==================================================================
+  return (
+    <div>
+      {/* Auth requirement notice */}
+      <div className="bg-white rounded-xl sm:rounded-2xl p-6 sm:p-8 shadow-lg">
+        <p className="text-sm sm:text-base text-gray-600 mb-6 text-center">
+          Абонаментните кутии изискват акаунт. Влез или създай нов, за да продължиш.
+        </p>
+
+        {/* Tab toggle */}
+        <div className="flex gap-2 sm:gap-3 mb-6">
+          <button
+            type="button"
+            onClick={() => switchTab('register')}
+            className={`flex-1 py-3 px-4 border-2 rounded-xl font-semibold text-sm sm:text-base transition-all ${
+              tab === 'register'
+                ? 'bg-[var(--color-brand-orange)] text-white border-[var(--color-brand-orange)]'
+                : 'bg-white text-[var(--color-brand-navy)] border-gray-300 hover:border-[var(--color-brand-orange)]'
+            }`}
+          >
+            Нов акаунт
+          </button>
+          <button
+            type="button"
+            onClick={() => switchTab('login')}
+            className={`flex-1 py-3 px-4 border-2 rounded-xl font-semibold text-sm sm:text-base transition-all ${
+              tab === 'login'
+                ? 'bg-[var(--color-brand-navy)] text-white border-[var(--color-brand-navy)]'
+                : 'bg-white text-[var(--color-brand-navy)] border-gray-300 hover:border-[var(--color-brand-navy)]'
+            }`}
+          >
+            Вече имам акаунт
+          </button>
+        </div>
+
+        {/* ---- FORM PHASE ---- */}
+        {phase === 'form' && (
+          <div className="space-y-4">
+            {tab === 'register' && (
+              <div>
+                <label htmlFor="inline-auth-name" className="block text-sm font-semibold text-[var(--color-brand-navy)] mb-1">
+                  Имена <span className="text-red-500">*</span>
+                </label>
+                <input
+                  id="inline-auth-name"
+                  type="text"
+                  value={fullName}
+                  onChange={(e) => setFullName(e.target.value)}
+                  placeholder="Иван Иванов"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-xl text-sm sm:text-base focus:outline-none focus:border-[var(--color-brand-orange)] transition-colors"
+                  autoComplete="name"
+                />
+              </div>
+            )}
+
+            <div>
+              <label htmlFor="inline-auth-email" className="block text-sm font-semibold text-[var(--color-brand-navy)] mb-1">
+                Имейл <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="inline-auth-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="email@example.com"
+                className="w-full px-4 py-3 border-2 border-gray-200 rounded-xl text-sm sm:text-base focus:outline-none focus:border-[var(--color-brand-orange)] transition-colors"
+                autoComplete="email"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-600 bg-red-50 px-4 py-2 rounded-lg">{error}</p>
+            )}
+
+            <button
+              type="button"
+              onClick={handleSendOtp}
+              disabled={sending}
+              className="w-full bg-[var(--color-brand-orange)] text-white py-3 rounded-xl font-semibold text-sm sm:text-base hover:bg-[#e67100] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {sending ? (
+                <span className="inline-flex items-center gap-2">
+                  <span className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full" />
+                  Изпращане...
+                </span>
+              ) : (
+                'Изпрати код за потвърждение'
+              )}
+            </button>
+          </div>
+        )}
+
+        {/* ---- OTP PHASE ---- */}
+        {phase === 'otp' && (
+          <div className="space-y-5">
+            <div className="text-center">
+              <p className="text-sm sm:text-base text-[var(--color-brand-navy)]">
+                Изпратихме 6-цифрен код на
+              </p>
+              <p className="font-semibold text-[var(--color-brand-navy)]">{email}</p>
+            </div>
+
+            {/* OTP digit inputs */}
+            <div
+              role="group"
+              aria-label="Код за потвърждение"
+              className="flex justify-center gap-2 sm:gap-3"
+            >
+              {otpDigits.map((digit, i) => (
+                <input
+                  key={i}
+                  ref={(el) => { otpRefs.current[i] = el; }}
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={1}
+                  value={digit}
+                  onChange={(e) => handleOtpChange(i, e.target.value)}
+                  onKeyDown={(e) => handleOtpKeyDown(i, e)}
+                  onPaste={i === 0 ? handleOtpPaste : undefined}
+                  disabled={isExpired || verifying}
+                  aria-label={`Цифра ${i + 1} от 6`}
+                  className={`w-11 h-13 sm:w-12 sm:h-14 text-center text-xl sm:text-2xl font-bold border-2 rounded-xl
+                    focus:outline-none transition-colors
+                    ${isExpired
+                      ? 'border-gray-200 bg-gray-100 text-gray-400 cursor-not-allowed'
+                      : 'border-gray-300 focus:border-[var(--color-brand-orange)] text-[var(--color-brand-navy)]'
+                    }
+                    ${verifying ? 'opacity-50 cursor-not-allowed' : ''}
+                  `}
+                />
+              ))}
+            </div>
+
+            {/* Verifying spinner */}
+            {verifying && (
+              <div className="flex justify-center">
+                <span className="inline-flex items-center gap-2 text-sm text-gray-500">
+                  <span className="animate-spin h-4 w-4 border-2 border-[var(--color-brand-orange)] border-t-transparent rounded-full" />
+                  Проверка...
+                </span>
+              </div>
+            )}
+
+            {/* Timer / Expired state */}
+            {!verifying && (
+              <div className="text-center">
+                {isExpired ? (
+                  <div className="space-y-3">
+                    <p className="text-sm text-red-600 font-semibold">Кодът изтече.</p>
+                    <button
+                      type="button"
+                      onClick={handleSendOtp}
+                      disabled={sending}
+                      className="text-sm font-semibold text-[var(--color-brand-orange)] hover:underline disabled:opacity-50"
+                    >
+                      {sending ? 'Изпращане...' : 'Изпрати нов код'}
+                    </button>
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">
+                    Кодът изтича след:{' '}
+                    <span className="font-mono font-semibold text-[var(--color-brand-navy)]">
+                      {formatTime(secondsLeft)}
+                    </span>
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Error */}
+            {error && (
+              <p className="text-sm text-red-600 bg-red-50 px-4 py-2 rounded-lg text-center">{error}</p>
+            )}
+
+            {/* Change email */}
+            <div className="text-center">
+              <button
+                type="button"
+                onClick={() => {
+                  setPhase('form');
+                  setError(null);
+                  setOtpDigits(['', '', '', '', '', '']);
+                }}
+                className="text-sm text-gray-500 hover:text-[var(--color-brand-navy)] hover:underline transition-colors"
+              >
+                ← Смени имейл
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Back button */}
+      <div className="flex justify-center mt-6">
+        <button
+          type="button"
+          onClick={onBack}
+          className="bg-gray-300 text-[var(--color-brand-navy)] px-6 sm:px-8 md:px-10 py-3 sm:py-4 rounded-full text-sm sm:text-base md:text-lg font-semibold uppercase tracking-wide hover:bg-gray-400 transition-all"
+        >
+          Назад
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/order/OrderStepDetails.tsx
+++ b/components/order/OrderStepDetails.tsx
@@ -18,6 +18,7 @@ import type { AddressInput, DeliveryMethod, SpeedyOfficeSelection } from '@/lib/
 import DeliveryMethodToggle from './DeliveryMethodToggle';
 import SpeedyOfficeSelector from './SpeedyOfficeSelector';
 import AdminCustomerPanel from './AdminCustomerPanel';
+import InlineAuth from './InlineAuth';
 import Link from 'next/link';
 
 interface OrderStepDetailsProps {
@@ -614,7 +615,7 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
   }
 
   // =========================================================================
-  // Branch A: Subscription + not authenticated
+  // Branch A: Subscription + not authenticated → inline OTP auth
   // =========================================================================
   if (isSubscription && !isAuthenticated) {
     return (
@@ -623,39 +624,13 @@ export default function OrderStepDetails({ onNext, onBack }: OrderStepDetailsPro
           Данни за доставка
         </h2>
 
-        <div className="bg-white rounded-xl sm:rounded-2xl p-6 sm:p-8 shadow-lg text-center">
-          <div className="text-5xl mb-4">🔒</div>
-          <h3 className="text-xl sm:text-2xl font-bold text-[var(--color-brand-navy)] mb-3">
-            Абонаментните кутии изискват акаунт.
-          </h3>
-          <p className="text-sm sm:text-base text-gray-600 mb-6">
-            Влез в акаунта си или създай нов, за да продължиш с абонамента.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-3 justify-center">
-            <Link
-              href="/login?redirect=/order"
-              className="bg-[var(--color-brand-orange)] text-white px-6 py-3 rounded-full font-semibold text-sm sm:text-base hover:bg-[#e67100] transition-all text-center"
-            >
-              Вход
-            </Link>
-            <Link
-              href="/register?redirect=/order"
-              className="bg-[var(--color-brand-navy)] text-white px-6 py-3 rounded-full font-semibold text-sm sm:text-base hover:bg-[#012a3f] transition-all text-center"
-            >
-              Регистрация
-            </Link>
-          </div>
-        </div>
-
-        {/* Back button */}
-        <div className="flex justify-center mt-6">
-          <button
-            onClick={onBack}
-            className="bg-gray-300 text-[var(--color-brand-navy)] px-6 sm:px-8 md:px-10 py-3 sm:py-4 rounded-full text-sm sm:text-base md:text-lg font-semibold uppercase tracking-wide hover:bg-gray-400 transition-all"
-          >
-            Назад
-          </button>
-        </div>
+        <InlineAuth
+          onAuthenticated={() => {
+            // Auth store updates via AuthProvider → isAuthenticated becomes true
+            // → Branch C renders on next re-render (address form)
+          }}
+          onBack={onBack}
+        />
       </div>
     );
   }

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -518,6 +518,54 @@ export function generatePasswordResetEmail(name: string, resetUrl: string): stri
 }
 
 // ============================================================================
+// OTP Verification Email Template
+// ============================================================================
+
+/**
+ * Generate a branded OTP verification email HTML.
+ * Sent during inline registration/login in the order flow.
+ *
+ * @param otp - The 6-digit OTP code
+ * @param name - User's display name (optional, omitted for login)
+ * @returns HTML string for the email
+ */
+export function generateOtpVerificationEmail(otp: string, name?: string): string {
+  const greeting = name
+    ? `Здравей, ${escapeHtml(name)}!`
+    : 'Здравей,';
+
+  const digitCells = otp
+    .split('')
+    .map(
+      (d) =>
+        `<td style="width: 44px; height: 52px; text-align: center; font-size: 28px; font-weight: 700; color: ${EMAIL.colors.textHeading}; background-color: #f9fafb; border: 2px solid #e5e7eb; border-radius: 8px; font-family: 'Courier New', Courier, monospace;">${d}</td>`,
+    )
+    .join('\n              ');
+
+  const bodyHtml = `
+  <h2 style="color: ${EMAIL.colors.textHeading}; margin-top: 0; font-size: 24px;">
+    ${greeting}
+  </h2>
+  <p style="color: ${EMAIL.colors.textPrimary}; font-size: 16px; line-height: 1.6;">
+    Твоят код за потвърждение е:
+  </p>
+  <table role="presentation" style="margin: 24px auto; border-collapse: separate; border-spacing: 8px;">
+    <tr>
+      ${digitCells}
+    </tr>
+  </table>
+  <p style="color: ${EMAIL.colors.textPrimary}; font-size: 16px; line-height: 1.6;">
+    Въведи този код в полето за потвърждение. Кодът е валиден 10 минути.
+  </p>
+  <p style="color: ${EMAIL.colors.textMuted}; font-size: 14px; line-height: 1.6;">
+    Ако не си заявил/а това, можеш спокойно да игнорираш този имейл.
+  </p>
+  ${emailContactLine()}
+`;
+  return wrapInEmailLayout(bodyHtml);
+}
+
+// ============================================================================
 // Delivery Confirmation Email Templates
 // ============================================================================
 

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -1174,6 +1174,30 @@ export interface Database {
         Update: ToRecord<SiteConfigUpdate>;
         Relationships: [];
       };
+      email_otp_verifications: {
+        Row: {
+          email: string;
+          otp_hash: string;
+          attempts: number;
+          created_at: string;
+          expires_at: string;
+        };
+        Insert: {
+          email: string;
+          otp_hash: string;
+          attempts?: number;
+          created_at?: string;
+          expires_at: string;
+        };
+        Update: {
+          email?: string;
+          otp_hash?: string;
+          attempts?: number;
+          created_at?: string;
+          expires_at?: string;
+        };
+        Relationships: [];
+      };
       user_profiles: {
         Row: ToRecord<UserProfileRow>;
         Insert: ToRecord<UserProfileInsert>;

--- a/supabase/migrations/20260412120000_create_email_otp_verifications.sql
+++ b/supabase/migrations/20260412120000_create_email_otp_verifications.sql
@@ -1,0 +1,23 @@
+-- Migration: Create email_otp_verifications table
+-- Short-lived OTP codes for inline email verification during order flow.
+-- Used for both registration and login via 6-digit codes.
+
+CREATE TABLE IF NOT EXISTS email_otp_verifications (
+  email       TEXT PRIMARY KEY,
+  otp_hash    TEXT NOT NULL,
+  attempts    SMALLINT NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at  TIMESTAMPTZ NOT NULL
+);
+
+-- Index for efficient cleanup of expired rows
+CREATE INDEX idx_email_otp_expires ON email_otp_verifications (expires_at);
+
+-- RLS: no client access, only service_role
+ALTER TABLE email_otp_verifications ENABLE ROW LEVEL SECURITY;
+-- No policies = no client access (service_role bypasses RLS)
+
+COMMENT ON TABLE email_otp_verifications IS 'Short-lived OTP codes for inline email verification during order flow';
+COMMENT ON COLUMN email_otp_verifications.otp_hash IS 'SHA-256 hash of the 6-digit OTP code';
+COMMENT ON COLUMN email_otp_verifications.attempts IS 'Number of verification attempts (max 5 before invalidation)';
+COMMENT ON COLUMN email_otp_verifications.expires_at IS 'OTP expiry timestamp (10 minutes after creation)';


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Issue #199 

---

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
Subscription orders previously redirected guests to a separate registration page, which caused sessionStorage loss (all order preferences wiped) when the activation email opened in a new tab. This also allowed creation of user with mistyped, undeliverable emails - creating phantom customer user entries. This PR replaces that flow with inline 6-digit OTP email verification on step 3, so guests never leave the order page. Email ownership is proven before the account or order is created, eliminating both issues.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [ ] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
