### PR TITLE
[RELEASE] Persist Speedy automat metadata on new address save

### DIFF
--- a/.changeset/fix-speedy-automat-address.md
+++ b/.changeset/fix-speedy-automat-address.md
@@ -1,0 +1,5 @@
+---
+"fitflow": patch
+---
+
+Fix Speedy automat address metadata not being saved during subscription checkout

--- a/.changeset/fix-speedy-automat-address.md
+++ b/.changeset/fix-speedy-automat-address.md
@@ -1,5 +1,0 @@
----
-"fitflow": patch
----
-
-Fix Speedy automat address metadata not being saved during subscription checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # fitflow
 
+## 1.7.1
+
+### Patch Changes
+
+- fbe15d8: Fix Speedy automat address metadata not being saved during subscription checkout
+
 ## 1.7.0
 
 ### Minor Changes

--- a/components/order/OrderFlow.tsx
+++ b/components/order/OrderFlow.tsx
@@ -208,7 +208,7 @@ export default function OrderFlow({
             ...currentInput.address,
             deliveryMethod: currentInput.deliveryMethod,
           };
-          if (currentInput.deliveryMethod === 'speedy_office' && currentInput.speedyOffice) {
+          if ((currentInput.deliveryMethod === 'speedy_office' || currentInput.deliveryMethod === 'speedy_automat') && currentInput.speedyOffice) {
             addressPayload.speedyOfficeId = currentInput.speedyOffice.id;
             addressPayload.speedyOfficeName = currentInput.speedyOffice.name;
             addressPayload.speedyOfficeAddress = currentInput.speedyOffice.address;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fitflow",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Closes #213

---

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
Subscription orders placed via the Speedy automat delivery method were silently losing the selected automat location details (ID, name, address) when the user entered a new inline address. This caused incomplete address records in the database and potential delivery failures. The condition now correctly handles both speedy_office and speedy_automat methods.

---

## Target branch checklist
- [ ] dev → feature work
- [ ] stage → release candidate
- [x] main → production only

---

## Release intent
- [x] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [x] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [ ] Tested on Vercel preview (if applicable)