### PR TITLE
[DEV] Restore PWA installability on Chrome mobile

### DIFF
--- a/.changeset/fix-pwa-installability.md
+++ b/.changeset/fix-pwa-installability.md
@@ -1,0 +1,5 @@
+---
+"fitflow": patch
+---
+
+Fix PWA installability: populate manifest name/short_name/start_url, add manifest meta link, and register a service worker

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,6 +33,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="bg">
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `if('serviceWorker' in navigator){navigator.serviceWorker.register('/sw.js')}`,
+          }}
+        />
+      </head>
       <body className="antialiased">
         <AuthProvider>
           {/* Marathon charity banner takes priority during May 2026; falls back to cutoff banner otherwise */}

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,1 +1,0 @@
-{"name":"","short_name":"","icons":[{"src":"/icon-192.png","sizes":"192x192","type":"image/png"},{"src":"/icon-512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "FitFlow - Кутия за АКТИВНИ дами",
+    short_name: "FitFlow",
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    theme_color: "#ffffff",
+    background_color: "#ffffff",
+    icons: [
+      { src: "/icon.png", sizes: "512x512", type: "image/png" },
+    ],
+  };
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,11 @@
+self.addEventListener("install", (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", (event) => {
+  event.respondWith(fetch(event.request));
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-self.addEventListener("install", (event) => {
+self.addEventListener("install", () => {
   self.skipWaiting();
 });
 


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Issue #217

---

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
The app stopped being detected as an installable PWA on Chrome mobile because the web manifest was missing required fields (name, short_name, start_url), no [<link rel="manifest">](vscode-file://vscode-app/c:/Users/angelnik/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was present in the document head, and there was no service worker registered. This fix populates the manifest, wires it into the Next.js metadata, and adds a minimal service worker so Chrome's installability criteria are met again and users can add the app to their home screen.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [ ] This PR does NOT bump versions (required unless targeting main)
- [x] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
