### PR TITLE
[DEV] Improve order-to-subscription conversion

### DIFF
--- a/.changeset/order-to-sub-conversion.md
+++ b/.changeset/order-to-sub-conversion.md
@@ -1,0 +1,5 @@
+---
+"fitflow": minor
+---
+
+Improve order-to-subscription conversion flow by pre-filling shipping address from the original order; fix speedy_automat delivery method not handled alongside speedy_office across email templates, order detail, address managers, and admin orders table

--- a/app/account/orders/[orderNumber]/page.tsx
+++ b/app/account/orders/[orderNumber]/page.tsx
@@ -229,10 +229,10 @@ export default async function OrderDetailPage({
       {/* Shipping Address Card */}
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6 mb-6">
         <h2 className="text-lg font-bold text-gray-900 mb-4">Адрес за доставка</h2>
-        {order.delivery_method === 'speedy_office' && (
+        {(order.delivery_method === 'speedy_office' || order.delivery_method === 'speedy_automat') && (
           <div className="flex items-center gap-2 mb-2">
             <span className="inline-block text-xs px-2 py-0.5 rounded-full font-semibold bg-blue-100 text-blue-700">
-              📦 До офис на Speedy
+              📦 {order.delivery_method === 'speedy_automat' ? 'До автомат на Speedy' : 'До офис на Speedy'}
             </span>
           </div>
         )}

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -93,7 +93,7 @@ export default async function OrdersPage({ searchParams }: OrdersPageProps) {
   function buildUrl(overrides: Record<string, string | undefined>) {
     const p = new URLSearchParams();
     const merged = {
-      cycleId: activeCycleId !== 'all' ? activeCycleId : undefined,
+      cycleId: activeCycleId,
       status: params.status,
       boxType: params.boxType,
       search: params.search,

--- a/app/api/admin/order/[id]/conversion-token/route.ts
+++ b/app/api/admin/order/[id]/conversion-token/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifySession } from '@/lib/auth/dal';
+import { ORDER_EDIT_ROLES } from '@/lib/auth/permissions';
+import { supabaseAdmin } from '@/lib/supabase/admin';
+import { validateOrderForConversion } from '@/lib/subscription/order-conversion';
+import type { OrderRow } from '@/lib/supabase/types';
+
+// ============================================================================
+// POST /api/admin/order/:id/conversion-token
+// Generate (or retrieve existing) subscription conversion token for an order.
+// ============================================================================
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  try {
+    // 1. Verify session + role
+    const session = await verifySession();
+    if (!session || session.profile.user_type !== 'staff') {
+      return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 });
+    }
+    if (!session.profile.staff_role || !ORDER_EDIT_ROLES.has(session.profile.staff_role)) {
+      return NextResponse.json({ error: 'Нямате права за тази операция.' }, { status: 403 });
+    }
+
+    // 2. Parse route params
+    const { id: orderId } = await params;
+
+    // 3. Fetch the order
+    const { data: order, error: fetchError } = await supabaseAdmin
+      .from('orders')
+      .select('*')
+      .eq('id', orderId)
+      .single();
+
+    if (fetchError || !order) {
+      return NextResponse.json({ error: 'Поръчката не е намерена.' }, { status: 404 });
+    }
+
+    const orderRow = order as OrderRow;
+
+    // 4. If already has a valid pending token, return it
+    if (
+      orderRow.subscription_conversion_status === 'pending' &&
+      orderRow.subscription_conversion_token
+    ) {
+      // Check if not expired
+      const expiresAt = orderRow.subscription_conversion_token_expires_at
+        ? new Date(orderRow.subscription_conversion_token_expires_at)
+        : null;
+
+      if (!expiresAt || expiresAt > new Date()) {
+        return NextResponse.json({
+          token: orderRow.subscription_conversion_token,
+          status: 'pending',
+          existing: true,
+        });
+      }
+      // Token expired - fall through to generate a new one
+    }
+
+    // 5. If already converted, reject
+    if (orderRow.subscription_conversion_status === 'converted' || orderRow.converted_to_subscription_id) {
+      return NextResponse.json(
+        { error: 'Поръчката вече е конвертирана в абонамент.' },
+        { status: 409 },
+      );
+    }
+
+    // 6. Validate eligibility
+    const eligibility = validateOrderForConversion(orderRow);
+    if (!eligibility.valid) {
+      return NextResponse.json(
+        { error: eligibility.reason ?? 'Поръчката не е подходяща за конвертиране.' },
+        { status: 400 },
+      );
+    }
+
+    // 7. Generate token
+    const token = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+
+    const { error: updateError } = await supabaseAdmin
+      .from('orders')
+      .update({
+        subscription_conversion_token: token,
+        subscription_conversion_token_expires_at: expiresAt,
+        subscription_conversion_status: 'pending',
+      })
+      .eq('id', orderId);
+
+    if (updateError) {
+      console.error('Error generating conversion token:', updateError);
+      return NextResponse.json(
+        { error: 'Грешка при генериране на токен.' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      token,
+      status: 'pending',
+      existing: false,
+    });
+  } catch (err) {
+    console.error('[admin/order/conversion-token POST]', err);
+    return NextResponse.json(
+      { error: 'Възникна неочаквана грешка.' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/subscription/convert/page.tsx
+++ b/app/subscription/convert/page.tsx
@@ -164,6 +164,7 @@ export default async function SubscriptionConvertPage({
     sizeUpper: order.size_upper,
     sizeLower: order.size_lower,
     additionalNotes: order.additional_notes,
+    shippingAddress: order.shipping_address ?? null,
     conversionToken: token,
     campaignPromoCode: promo || null,
   };

--- a/components/account/AddressesManager.tsx
+++ b/components/account/AddressesManager.tsx
@@ -20,9 +20,9 @@ type FormMode = 'hidden' | 'create' | 'edit';
 // ============================================================================
 
 function formatAddressDisplay(addr: AddressRow): { primary: string; secondary?: string } {
-  if (addr.delivery_method === 'speedy_office') {
+  if (addr.delivery_method === 'speedy_office' || addr.delivery_method === 'speedy_automat') {
     return {
-      primary: addr.speedy_office_name ?? 'Speedy офис',
+      primary: addr.speedy_office_name ?? (addr.delivery_method === 'speedy_automat' ? 'Speedy автомат' : 'Speedy офис'),
       secondary: addr.speedy_office_address ?? undefined,
     };
   }

--- a/components/account/SubscriptionCard.tsx
+++ b/components/account/SubscriptionCard.tsx
@@ -65,7 +65,7 @@ export default function SubscriptionCard({
   const address = addresses.find((a) => a.id === subscription.default_address_id);
   const addressLabel = address?.label || null;
   const addressDetail = address
-    ? address.delivery_method === 'speedy_office'
+    ? (address.delivery_method === 'speedy_office' || address.delivery_method === 'speedy_automat')
       ? address.speedy_office_name ?? ''
       : [address.street_address, address.city, address.postal_code].filter(Boolean).join(', ')
     : null;

--- a/components/account/modals/AddressModal.tsx
+++ b/components/account/modals/AddressModal.tsx
@@ -49,8 +49,8 @@ export default function AddressModal({
   };
 
   const formatAddress = (addr: AddressRow) => {
-    if (addr.delivery_method === 'speedy_office') {
-      return addr.speedy_office_name ?? 'Speedy офис';
+    if (addr.delivery_method === 'speedy_office' || addr.delivery_method === 'speedy_automat') {
+      return addr.speedy_office_name ?? (addr.delivery_method === 'speedy_automat' ? 'Speedy автомат' : 'Speedy офис');
     }
     const parts = [addr.street_address, addr.city, addr.postal_code].filter(Boolean);
     if (addr.building_entrance) parts.push(`вх. ${addr.building_entrance}`);
@@ -102,7 +102,7 @@ export default function AddressModal({
                     )}
                   </div>
                   <p className="text-xs text-gray-500 mt-0.5 truncate">
-                    {addr.delivery_method === 'speedy_office' ? (
+                    {(addr.delivery_method === 'speedy_office' || addr.delivery_method === 'speedy_automat') ? (
                       <>
                         <span>📦 {formatAddress(addr)}</span>
                         {addr.speedy_office_address && (

--- a/components/admin/AdminAddressManager.tsx
+++ b/components/admin/AdminAddressManager.tsx
@@ -29,9 +29,9 @@ type FormMode = 'hidden' | 'create' | 'edit';
 // ============================================================================
 
 function formatAddressDisplay(addr: AddressRow): { primary: string; secondary?: string } {
-  if (addr.delivery_method === 'speedy_office') {
+  if (addr.delivery_method === 'speedy_office' || addr.delivery_method === 'speedy_automat') {
     return {
-      primary: addr.speedy_office_name ?? 'Speedy офис',
+      primary: addr.speedy_office_name ?? (addr.delivery_method === 'speedy_automat' ? 'Speedy автомат' : 'Speedy офис'),
       secondary: addr.speedy_office_address ?? undefined,
     };
   }
@@ -288,7 +288,7 @@ export default function AdminAddressManager({
                     {addr.label || 'Без етикет'}
                   </span>
                   <span className="text-xs text-gray-500">
-                    {addr.delivery_method === 'speedy_office' ? '📦 Speedy' : '📍 Адрес'}
+                    {(addr.delivery_method === 'speedy_office' || addr.delivery_method === 'speedy_automat') ? '📦 Speedy' : '📍 Адрес'}
                   </span>
                   {addr.is_default && (
                     <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-[var(--color-brand-orange)] text-white">

--- a/components/admin/OrderConversionAction.tsx
+++ b/components/admin/OrderConversionAction.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState } from 'react';
+import type { OrderRow } from '@/lib/supabase/types';
+
+interface OrderConversionActionProps {
+  order: OrderRow;
+  onSuccess: () => void;
+}
+
+/** One-time order types eligible for conversion */
+const CONVERTIBLE_ORDER_TYPES = new Set([
+  'onetime-mystery',
+  'onetime-revealed',
+  'direct',
+]);
+
+export default function OrderConversionAction({
+  order,
+  onSuccess,
+}: OrderConversionActionProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+
+  // Determine current state
+  const isConverted =
+    order.subscription_conversion_status === 'converted' ||
+    order.converted_to_subscription_id != null;
+
+  const hasPendingToken =
+    order.subscription_conversion_status === 'pending' &&
+    order.subscription_conversion_token != null;
+
+  // Only show for eligible order types
+  if (!CONVERTIBLE_ORDER_TYPES.has(order.order_type)) return null;
+  // Don't show for subscription-generated orders
+  if (order.subscription_id) return null;
+
+  function buildConversionUrl(token: string) {
+    return `${window.location.origin}/subscription/convert?token=${token}`;
+  }
+
+  function copyToClipboard(text: string) {
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(text).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }).catch(() => {
+        fallbackCopy(text);
+      });
+    } else {
+      fallbackCopy(text);
+    }
+  }
+
+  function fallbackCopy(text: string) {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand('copy');
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      window.prompt('Копирайте линка:', text);
+    }
+    document.body.removeChild(textarea);
+  }
+
+  async function generateAndCopy() {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/admin/order/${order.id}/conversion-token`, {
+        method: 'POST',
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error ?? 'Грешка при генериране на линк.');
+      }
+
+      const token = data.token as string;
+      setGeneratedToken(token);
+      copyToClipboard(buildConversionUrl(token));
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Неочаквана грешка.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const activeToken = generatedToken ?? order.subscription_conversion_token;
+
+  return (
+    <div className="mt-3">
+      <h4 className="font-semibold text-[var(--color-brand-navy)] text-xs mb-1">
+        Конвертиране в абонамент
+      </h4>
+
+      {isConverted ? (
+        <p className="text-xs text-green-600 font-medium">
+          ✓ Конвертирана в абонамент
+        </p>
+      ) : hasPendingToken || generatedToken ? (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-amber-600 font-medium">Чака конвертиране</span>
+          <button
+            onClick={() => copyToClipboard(buildConversionUrl(activeToken!))}
+            className="text-xs text-[var(--color-brand-orange)] hover:underline"
+            title="Копирай линк за конвертиране"
+          >
+            {copied ? '✓ Копирано!' : '📋 Копирай линк'}
+          </button>
+        </div>
+      ) : order.status === 'delivered' ? (
+        <button
+          onClick={generateAndCopy}
+          disabled={loading}
+          className="text-xs px-3 py-1 rounded-lg bg-[var(--color-brand-navy)] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+        >
+          {loading ? 'Генериране...' : '🔀 Генерирай линк'}
+        </button>
+      ) : (
+        <p className="text-xs text-gray-400 italic">
+          Поръчката трябва да е доставена
+        </p>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-600 mt-1">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/components/admin/OrdersTable.tsx
+++ b/components/admin/OrdersTable.tsx
@@ -11,6 +11,7 @@ import { formatShippingAddressOneLine, ALLOWED_TRANSITIONS } from '@/lib/order';
 import { formatPriceDual, eurToBgnSync } from '@/lib/catalog';
 import { formatDateTimeShort } from '@/lib/utils/date';
 import OrderPromoAction from './OrderPromoAction';
+import OrderConversionAction from './OrderConversionAction';
 
 // ============================================================================
 // Types
@@ -789,6 +790,9 @@ function OrderRowDetail({
             Преобразувана от предварителна поръчка
           </p>
         )}
+
+        {/* Subscription conversion action */}
+        <OrderConversionAction order={order} onSuccess={onRefresh} />
 
         {/* Admin promo management */}
         <OrderPromoAction

--- a/components/subscription/SubscriptionConversionFlow.tsx
+++ b/components/subscription/SubscriptionConversionFlow.tsx
@@ -99,17 +99,34 @@ export default function SubscriptionConversionFlow({
   const [lastName, setLastName] = useState(source.customerLastName);
   const [phone, setPhone] = useState(source.customerPhone ?? '');
 
-  // ── Step 2: address ─────────────────────────────────────────────────────
+  // ── Step 2: address (pre-fill from order's shipping address) ────────────
+  const srcAddr = source.shippingAddress;
   const [address, setAddress] = useState<AddressInput>({
     ...EMPTY_ADDRESS,
-    firstName: source.customerFirstName,
-    lastName: source.customerLastName,
-    phone: source.customerPhone ?? '',
+    firstName: srcAddr?.first_name ?? source.customerFirstName,
+    lastName: srcAddr?.last_name ?? source.customerLastName,
+    phone: srcAddr?.phone ?? source.customerPhone ?? '',
+    city: srcAddr?.city ?? '',
+    postalCode: srcAddr?.postal_code ?? '',
+    streetAddress: srcAddr?.street_address ?? '',
+    buildingEntrance: srcAddr?.building_entrance ?? '',
+    floor: srcAddr?.floor ?? '',
+    apartment: srcAddr?.apartment ?? '',
+    deliveryNotes: srcAddr?.delivery_notes ?? '',
   });
-  const [deliveryMethod, setDeliveryMethod] = useState<DeliveryMethod>('address');
+  const initialDeliveryMethod: DeliveryMethod = srcAddr?.delivery_method ?? 'address';
+  const [deliveryMethod, setDeliveryMethod] = useState<DeliveryMethod>(initialDeliveryMethod);
   const { pricing: deliveryPricing } = useDeliveryPricing();
   const deliveryFeeEur = deliveryPricing.get(deliveryMethod)?.priceEur ?? 0;
-  const [speedyOffice, setSpeedyOffice] = useState<SpeedyOfficeSelection | null>(null);
+  const [speedyOffice, setSpeedyOffice] = useState<SpeedyOfficeSelection | null>(
+    srcAddr?.speedy_office_id
+      ? {
+          id: srcAddr.speedy_office_id,
+          name: srcAddr.speedy_office_name ?? '',
+          address: srcAddr.speedy_office_address ?? '',
+        }
+      : null,
+  );
   const [officeError, setOfficeError] = useState<string | null>(null);
 
   // Saved addresses (authenticated)

--- a/components/subscription/conversion-types.ts
+++ b/components/subscription/conversion-types.ts
@@ -1,5 +1,5 @@
 import type { CatalogData, PriceInfo } from '@/lib/catalog';
-import type { DeliveryCycleRow } from '@/lib/supabase/types';
+import type { DeliveryCycleRow, ShippingAddressSnapshot } from '@/lib/supabase/types';
 
 // ============================================================================
 // Conversion Source Type
@@ -25,6 +25,7 @@ export interface SubscriptionConversionSource {
   sizeUpper: string | null;
   sizeLower: string | null;
   additionalNotes: string | null;
+  shippingAddress: ShippingAddressSnapshot | null;
   conversionToken: string;
   campaignPromoCode: string | null;
 }

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -133,10 +133,12 @@ function generateDeliverySection(data: ConfirmationEmailData): string {
 
   let addressHtml = '';
 
-  if (data.deliveryMethod === 'speedy_office') {
+  if (data.deliveryMethod === 'speedy_office' || data.deliveryMethod === 'speedy_automat') {
+    const methodLabel = data.deliveryMethod === 'speedy_automat' ? 'До автомат на Speedy' : 'До офис на Speedy';
+    const locationLabel = data.deliveryMethod === 'speedy_automat' ? 'Автомат' : 'Офис';
     addressHtml = `
-      <p style="margin: 5px 0;"><strong>Метод на доставка:</strong> До офис на Speedy</p>
-      ${data.speedyOfficeName ? `<p style="margin: 5px 0;"><strong>Офис:</strong> ${escapeHtml(data.speedyOfficeName)}</p>` : ''}
+      <p style="margin: 5px 0;"><strong>Метод на доставка:</strong> ${methodLabel}</p>
+      ${data.speedyOfficeName ? `<p style="margin: 5px 0;"><strong>${locationLabel}:</strong> ${escapeHtml(data.speedyOfficeName)}</p>` : ''}
       ${data.speedyOfficeAddress ? `<p style="margin: 5px 0; color: ${EMAIL.colors.textMutedAlt}; font-size: 14px;">${escapeHtml(data.speedyOfficeAddress)}</p>` : ''}
     `;
   } else {


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Issue #221 

---

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
Customers converting a single order into a subscription no longer need to re-enter their shipping details — the conversion flow now pre-fills all address fields (including Speedy office/automat selection) from the original order. This also fixes a bug where Speedy locker (speedy_automat) deliveries were shown as "personal address" in confirmation emails, order detail pages, and address managers, because those components only checked for speedy_office. The admin orders table now includes an inline conversion action and the cycle filter works correctly.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [ ] This PR does NOT bump versions (required unless targeting main)
- [x] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [ ] Tested on Vercel preview (if applicable)
