### PR TITLE
[STAGE] Complete Speedy waybill fields & inline address creation

### DIFF
--- a/.changeset/admin-add-address-subscription-picker.md
+++ b/.changeset/admin-add-address-subscription-picker.md
@@ -1,0 +1,7 @@
+---
+"fitflow": minor
+---
+
+Allow admins to create a new address directly from the subscription address picker modal
+
+Admins can now add a new delivery address for a customer without leaving the subscription detail page. The inline form pre-fills name and phone from the customer profile, filters the Speedy widget by delivery method, and correctly handles the default-address flag to prevent duplicate defaults.

--- a/.changeset/fix-speedy-waybill-fields.md
+++ b/.changeset/fix-speedy-waybill-fields.md
@@ -1,0 +1,7 @@
+---
+"fitflow": patch
+---
+
+Fix Speedy waybill creation to include COD, declared value, dropoff office, and correct parcel defaults
+
+Waybills generated via the Speedy API were missing cash-on-delivery, declared value, and sender dropoff office fields. Parcel weight, contents, and packaging also did not match actual shipment data. All values are now sent correctly and are configurable through the admin Dispatch settings page via `site_config`.

--- a/app/admin/settings/dispatch/page.tsx
+++ b/app/admin/settings/dispatch/page.tsx
@@ -20,11 +20,13 @@ export default async function DispatchSettingsPage() {
   // Read parcel config from DB
   const configMap = await getDeliveryConfigMap();
   const parcelConfig = {
-    weight: configMap.PARCEL_WEIGHT_KG || '2.5',
-    width: configMap.PARCEL_WIDTH_CM || '30',
-    depth: configMap.PARCEL_DEPTH_CM || '30',
-    height: configMap.PARCEL_HEIGHT_CM || '15',
-    contents: configMap.PARCEL_CONTENTS || 'Фитнес кутия',
+    weight: configMap.PARCEL_WEIGHT_KG || '1.36',
+    width: configMap.PARCEL_WIDTH_CM || '19',
+    depth: configMap.PARCEL_DEPTH_CM || '26.5',
+    height: configMap.PARCEL_HEIGHT_CM || '10',
+    contents: configMap.PARCEL_CONTENTS || 'КУТИЯ СЪС СПОРТНИ СТОКИ',
+    package: configMap.PARCEL_PACKAGE || 'КАШОН',
+    dropoffOfficeId: configMap.SPEEDY_DROPOFF_OFFICE_ID || '189',
   };
 
   return (

--- a/app/admin/subscriptions/[id]/page.tsx
+++ b/app/admin/subscriptions/[id]/page.tsx
@@ -62,9 +62,8 @@ export default async function SubscriptionDetailPage({ params }: { params: Promi
     supabaseAdmin.auth.admin.getUserById(subscription.user_id),
   ]);
 
-  const userName = profileResult.data
-    ? `${profileResult.data.first_name} ${profileResult.data.last_name}`.trim()
-    : 'Неизвестен';
+  const userFirstName = profileResult.data?.first_name ?? '';
+  const userLastName = profileResult.data?.last_name ?? '';
   const userEmail = authResult.data?.user?.email ?? '';
 
   return (
@@ -84,7 +83,8 @@ export default async function SubscriptionDetailPage({ params }: { params: Promi
         defaultAddress={address}
         allAddresses={allAddresses}
         canManage={canManage}
-        userName={userName}
+        userFirstName={userFirstName}
+        userLastName={userLastName}
         userEmail={userEmail}
         eurToBgnRate={eurToBgnRate}
       />

--- a/app/api/admin/address/route.ts
+++ b/app/api/admin/address/route.ts
@@ -276,6 +276,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             is_default: sanitized.isDefault ?? false,
           };
 
+    // Explicitly unset other defaults before insert (defense against trigger edge cases)
+    if (insertData.is_default) {
+      await supabaseAdmin
+        .from('addresses')
+        .update({ is_default: false })
+        .eq('user_id', userId)
+        .eq('is_default', true);
+    }
+
     const address = await createAddress(insertData);
 
     // Sync phone to profile if profile phone is empty

--- a/app/api/admin/speedy/calculate/route.ts
+++ b/app/api/admin/speedy/calculate/route.ts
@@ -58,9 +58,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       userEmail: order.customer_email,
       userPhone: order.customer_phone || addr.phone || '',
       readableId: order.order_number,
+      finalPriceEur: Number(order.final_price_eur) || 0,
+      deliveryFeeEur: Number(order.delivery_fee_eur) || 0,
     };
 
-    const params = buildShipmentRequest(orderForShipment);
+    const params = await buildShipmentRequest(orderForShipment);
     const calcResult = await calculateShipment(params);
 
     const calculation = calcResult.calculations[0];

--- a/app/api/admin/speedy/shipment/bulk/route.ts
+++ b/app/api/admin/speedy/shipment/bulk/route.ts
@@ -99,6 +99,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           userEmail: order.customer_email,
           userPhone: order.customer_phone || addr.phone || '',
           readableId: order.order_number,
+          finalPriceEur: Number(order.final_price_eur) || 0,
+          deliveryFeeEur: Number(order.delivery_fee_eur) || 0,
         };
 
         const result = await createWaybillForOrder(orderForShipment);

--- a/app/api/admin/speedy/shipment/route.ts
+++ b/app/api/admin/speedy/shipment/route.ts
@@ -70,6 +70,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       userEmail: order.customer_email,
       userPhone: order.customer_phone || addr.phone || '',
       readableId: order.order_number,
+      finalPriceEur: Number(order.final_price_eur) || 0,
+      deliveryFeeEur: Number(order.delivery_fee_eur) || 0,
     };
 
     // 5. Create waybill via Speedy API

--- a/components/admin/AdminAddressForm.tsx
+++ b/components/admin/AdminAddressForm.tsx
@@ -467,6 +467,7 @@ export default function AdminAddressForm({
           <SpeedyOfficeSelector
             selectedOffice={speedyOffice}
             onSelect={handleOfficeSelect}
+            deliveryMethod={deliveryMethod}
             error={errorFor('speedyOffice')}
           />
         </div>

--- a/components/admin/ParcelConfigEditor.tsx
+++ b/components/admin/ParcelConfigEditor.tsx
@@ -9,6 +9,8 @@ interface ParcelConfigEditorProps {
     depth: string;
     height: string;
     contents: string;
+    package: string;
+    dropoffOfficeId: string;
   };
 }
 
@@ -18,6 +20,8 @@ export default function ParcelConfigEditor({ initialConfig }: ParcelConfigEditor
   const [depth, setDepth] = useState(initialConfig.depth);
   const [height, setHeight] = useState(initialConfig.height);
   const [contents, setContents] = useState(initialConfig.contents);
+  const [pkg, setPkg] = useState(initialConfig.package);
+  const [dropoffOfficeId, setDropoffOfficeId] = useState(initialConfig.dropoffOfficeId);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
@@ -26,7 +30,9 @@ export default function ParcelConfigEditor({ initialConfig }: ParcelConfigEditor
     width !== initialConfig.width ||
     depth !== initialConfig.depth ||
     height !== initialConfig.height ||
-    contents !== initialConfig.contents;
+    contents !== initialConfig.contents ||
+    pkg !== initialConfig.package ||
+    dropoffOfficeId !== initialConfig.dropoffOfficeId;
 
   const handleSave = useCallback(async () => {
     setSaving(true);
@@ -38,6 +44,8 @@ export default function ParcelConfigEditor({ initialConfig }: ParcelConfigEditor
     if (depth !== initialConfig.depth) updates.push({ key: 'PARCEL_DEPTH_CM', value: depth });
     if (height !== initialConfig.height) updates.push({ key: 'PARCEL_HEIGHT_CM', value: height });
     if (contents !== initialConfig.contents) updates.push({ key: 'PARCEL_CONTENTS', value: contents });
+    if (pkg !== initialConfig.package) updates.push({ key: 'PARCEL_PACKAGE', value: pkg });
+    if (dropoffOfficeId !== initialConfig.dropoffOfficeId) updates.push({ key: 'SPEEDY_DROPOFF_OFFICE_ID', value: dropoffOfficeId });
 
     try {
       for (const { key, value } of updates) {
@@ -57,7 +65,7 @@ export default function ParcelConfigEditor({ initialConfig }: ParcelConfigEditor
     } finally {
       setSaving(false);
     }
-  }, [weight, width, depth, height, contents, initialConfig]);
+  }, [weight, width, depth, height, contents, pkg, dropoffOfficeId, initialConfig]);
 
   return (
     <div className="bg-gray-50 rounded-xl border p-5 space-y-4">
@@ -81,6 +89,16 @@ export default function ParcelConfigEditor({ initialConfig }: ParcelConfigEditor
             maxLength={100}
             value={contents}
             onChange={(e) => setContents(e.target.value)}
+            className="w-full border rounded-lg px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-gray-600 font-medium mb-1">Опаковка</label>
+          <input
+            type="text"
+            maxLength={50}
+            value={pkg}
+            onChange={(e) => setPkg(e.target.value)}
             className="w-full border rounded-lg px-3 py-2 text-sm"
           />
         </div>
@@ -117,6 +135,17 @@ export default function ParcelConfigEditor({ initialConfig }: ParcelConfigEditor
             max="200"
             value={height}
             onChange={(e) => setHeight(e.target.value)}
+            className="w-full border rounded-lg px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-gray-600 font-medium mb-1">Dropoff офис ID</label>
+          <input
+            type="number"
+            step="1"
+            min="1"
+            value={dropoffOfficeId}
+            onChange={(e) => setDropoffOfficeId(e.target.value)}
             className="w-full border rounded-lg px-3 py-2 text-sm"
           />
         </div>

--- a/components/admin/SubscriptionDetailView.tsx
+++ b/components/admin/SubscriptionDetailView.tsx
@@ -8,6 +8,7 @@ import { SUBSCRIPTION_STATUS_LABELS, SUBSCRIPTION_STATUS_COLORS, FREQUENCY_LABEL
 import { formatDateTimeShort } from '@/lib/utils/date';
 import { formatPriceDual, eurToBgnSync } from '@/lib/catalog';
 import type { OrderRow, AddressRow } from '@/lib/supabase/types';
+import AdminAddressForm from '@/components/admin/AdminAddressForm';
 
 // ============================================================================
 // Constants
@@ -76,7 +77,8 @@ interface SubscriptionDetailViewProps {
   defaultAddress: AddressRow | null;
   allAddresses: AddressRow[];
   canManage: boolean;
-  userName: string;
+  userFirstName: string;
+  userLastName: string;
   userEmail: string;
   eurToBgnRate: number;
 }
@@ -94,7 +96,8 @@ export function SubscriptionDetailView({
   defaultAddress,
   allAddresses,
   canManage,
-  userName,
+  userFirstName,
+  userLastName,
   userEmail,
   eurToBgnRate,
 }: SubscriptionDetailViewProps) {
@@ -116,6 +119,8 @@ export function SubscriptionDetailView({
   const [selectedAddressId, setSelectedAddressId] = useState<string | null>(
     subscription.default_address_id ?? null,
   );
+  const [showNewAddressForm, setShowNewAddressForm] = useState(false);
+  const [localAddresses, setLocalAddresses] = useState<AddressRow[]>(allAddresses);
   const [showFrequencyPicker, setShowFrequencyPicker] = useState(false);
   const [selectedFrequency, setSelectedFrequency] = useState<string>(subscription.frequency);
   const [showPromoEditor, setShowPromoEditor] = useState(false);
@@ -270,7 +275,7 @@ export function SubscriptionDetailView({
 
         {/* Info Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <InfoItem label="Потребител" value={`${userName} (${userEmail})`} />
+          <InfoItem label="Потребител" value={`${userFirstName} ${userLastName} (${userEmail})`} />
           <InfoItem
             label="Статус"
             value={
@@ -737,83 +742,122 @@ export function SubscriptionDetailView({
       {/* ================================================================ */}
       {showAddressPicker && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div className="absolute inset-0 bg-black/50" onClick={() => setShowAddressPicker(false)} />
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => {
+              setShowAddressPicker(false);
+              setShowNewAddressForm(false);
+            }}
+          />
           <div className="relative bg-white rounded-xl shadow-xl p-6 max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto">
             <h3 className="text-lg font-bold text-[var(--color-brand-navy)] mb-4">
-              Промяна на адрес за абонамент
+              {showNewAddressForm ? 'Нов адрес' : 'Промяна на адрес за абонамент'}
             </h3>
 
-            <div className="space-y-2">
-              {/* No address option */}
-              <label className="flex items-start gap-3 p-3 rounded-lg border cursor-pointer hover:bg-gray-50 transition-colors" style={{ borderColor: selectedAddressId === null ? 'var(--color-brand-navy)' : undefined }}>
-                <input
-                  type="radio"
-                  name="address"
-                  checked={selectedAddressId === null}
-                  onChange={() => setSelectedAddressId(null)}
-                  className="mt-1"
-                />
-                <span className="text-sm text-gray-600">Без адрес</span>
-              </label>
+            {showNewAddressForm ? (
+              <AdminAddressForm
+                mode="create"
+                userId={subscription.user_id}
+                customerDefaults={{ firstName: userFirstName, lastName: userLastName, phone: defaultAddress?.phone ?? '' }}
+                onSuccess={(newAddress) => {
+                  setLocalAddresses((prev) =>
+                    [
+                      ...prev.map((a) =>
+                        newAddress.is_default ? { ...a, is_default: false } : a,
+                      ),
+                      newAddress,
+                    ],
+                  );
+                  setSelectedAddressId(newAddress.id);
+                  setShowNewAddressForm(false);
+                }}
+                onCancel={() => setShowNewAddressForm(false)}
+              />
+            ) : (
+              <>
+                <div className="space-y-2">
+                  {/* No address option */}
+                  <label className="flex items-start gap-3 p-3 rounded-lg border cursor-pointer hover:bg-gray-50 transition-colors" style={{ borderColor: selectedAddressId === null ? 'var(--color-brand-navy)' : undefined }}>
+                    <input
+                      type="radio"
+                      name="address"
+                      checked={selectedAddressId === null}
+                      onChange={() => setSelectedAddressId(null)}
+                      className="mt-1"
+                    />
+                    <span className="text-sm text-gray-600">Без адрес</span>
+                  </label>
 
-              {allAddresses.map((addr) => (
-                <label
-                  key={addr.id}
-                  className="flex items-start gap-3 p-3 rounded-lg border cursor-pointer hover:bg-gray-50 transition-colors"
-                  style={{ borderColor: selectedAddressId === addr.id ? 'var(--color-brand-navy)' : undefined }}
-                >
-                  <input
-                    type="radio"
-                    name="address"
-                    checked={selectedAddressId === addr.id}
-                    onChange={() => setSelectedAddressId(addr.id)}
-                    className="mt-1"
-                  />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      {addr.label && (
-                        <span className="text-sm font-semibold text-gray-900">{addr.label}</span>
-                      )}
-                      <span
-                        className={`text-xs font-semibold px-2 py-0.5 rounded ${
-                          addr.delivery_method === 'speedy_office'
-                            ? 'bg-orange-100 text-orange-800'
-                            : 'bg-blue-100 text-blue-800'
-                        }`}
-                      >
-                        {addr.delivery_method === 'speedy_office' ? 'Speedy офис' : 'До адрес'}
-                      </span>
-                      {addr.is_default && (
-                        <span className="text-xs font-semibold px-2 py-0.5 rounded bg-green-100 text-green-800">
-                          По подразбиране
-                        </span>
-                      )}
-                    </div>
-                    <p className="text-sm text-gray-600 mt-1">{formatAddress(addr)}</p>
-                    {addr.phone && (
-                      <p className="text-xs text-gray-400 mt-0.5">Тел: {addr.phone}</p>
-                    )}
-                  </div>
-                </label>
-              ))}
-            </div>
+                  {localAddresses.map((addr) => (
+                    <label
+                      key={addr.id}
+                      className="flex items-start gap-3 p-3 rounded-lg border cursor-pointer hover:bg-gray-50 transition-colors"
+                      style={{ borderColor: selectedAddressId === addr.id ? 'var(--color-brand-navy)' : undefined }}
+                    >
+                      <input
+                        type="radio"
+                        name="address"
+                        checked={selectedAddressId === addr.id}
+                        onChange={() => setSelectedAddressId(addr.id)}
+                        className="mt-1"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          {addr.label && (
+                            <span className="text-sm font-semibold text-gray-900">{addr.label}</span>
+                          )}
+                          <span
+                            className={`text-xs font-semibold px-2 py-0.5 rounded ${
+                              addr.delivery_method === 'speedy_office'
+                                ? 'bg-orange-100 text-orange-800'
+                                : 'bg-blue-100 text-blue-800'
+                            }`}
+                          >
+                            {addr.delivery_method === 'speedy_office' ? 'Speedy офис' : 'До адрес'}
+                          </span>
+                          {addr.is_default && (
+                            <span className="text-xs font-semibold px-2 py-0.5 rounded bg-green-100 text-green-800">
+                              По подразбиране
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-sm text-gray-600 mt-1">{formatAddress(addr)}</p>
+                        {addr.phone && (
+                          <p className="text-xs text-gray-400 mt-0.5">Тел: {addr.phone}</p>
+                        )}
+                      </div>
+                    </label>
+                  ))}
+                </div>
 
-            <div className="flex gap-3 justify-end mt-4">
-              <button
-                onClick={() => setShowAddressPicker(false)}
-                className="px-4 py-2 text-sm border rounded-lg hover:bg-gray-50"
-                disabled={isPending}
-              >
-                Отказ
-              </button>
-              <button
-                onClick={handleSaveAddress}
-                disabled={isPending}
-                className="px-4 py-2 text-sm bg-[var(--color-brand-navy)] text-white rounded-lg font-semibold hover:opacity-90 disabled:opacity-50"
-              >
-                {isPending ? 'Запазва се...' : 'Запази'}
-              </button>
-            </div>
+                {canManage && (
+                  <button
+                    type="button"
+                    onClick={() => setShowNewAddressForm(true)}
+                    className="mt-3 w-full inline-flex items-center justify-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:border-[var(--color-brand-orange)] hover:text-[var(--color-brand-orange)]"
+                  >
+                    + Добави нов адрес
+                  </button>
+                )}
+
+                <div className="flex gap-3 justify-end mt-4">
+                  <button
+                    onClick={() => setShowAddressPicker(false)}
+                    className="px-4 py-2 text-sm border rounded-lg hover:bg-gray-50"
+                    disabled={isPending}
+                  >
+                    Отказ
+                  </button>
+                  <button
+                    onClick={handleSaveAddress}
+                    disabled={isPending}
+                    className="px-4 py-2 text-sm bg-[var(--color-brand-navy)] text-white rounded-lg font-semibold hover:opacity-90 disabled:opacity-50"
+                  >
+                    {isPending ? 'Запазва се...' : 'Запази'}
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/lib/data/delivery-cycles.ts
+++ b/lib/data/delivery-cycles.ts
@@ -40,6 +40,8 @@ const DELIVERY_CONFIG_KEYS = [
   'PARCEL_DEPTH_CM',
   'PARCEL_HEIGHT_CM',
   'PARCEL_CONTENTS',
+  'PARCEL_PACKAGE',
+  'SPEEDY_DROPOFF_OFFICE_ID',
 ] as const;
 
 type DeliveryConfigKey = (typeof DELIVERY_CONFIG_KEYS)[number];

--- a/lib/delivery/speedy/config.ts
+++ b/lib/delivery/speedy/config.ts
@@ -3,20 +3,36 @@
  *
  * clientId is obtained from the Contract Clients endpoint (admin/speedy setup page).
  * serviceId is the courier service to use for domestic shipments.
+ * dropoffOfficeId is read from site_config DB, env var, or defaults to 189.
  */
 
 import 'server-only';
 
+import { getDeliveryConfigMap } from '@/lib/data';
+
 export const SPEEDY_SENDER_CLIENT_ID = Number(process.env.SPEEDY_CLIENT_ID) || 0;
 export const SPEEDY_SERVICE_ID = Number(process.env.SPEEDY_SERVICE_ID) || 505;
+// TODO: Make this a dropdown in the admin Speedy setup page
+export const SPEEDY_DROPOFF_OFFICE_ID_DEFAULT = Number(process.env.SPEEDY_DROPOFF_OFFICE_ID) || 189;
 
-export function getSpeedySenderConfig() {
+export async function getSpeedySenderConfig() {
   if (!SPEEDY_SENDER_CLIENT_ID) {
     throw new Error('SPEEDY_CLIENT_ID env var not set. Run admin/speedy setup page to discover it.');
   }
+
+  let dropoffOfficeId = SPEEDY_DROPOFF_OFFICE_ID_DEFAULT;
+  try {
+    const configMap = await getDeliveryConfigMap();
+    const dbValue = Number(configMap.SPEEDY_DROPOFF_OFFICE_ID);
+    if (dbValue) dropoffOfficeId = dbValue;
+  } catch {
+    // Fall through to env/default
+  }
+
   return {
     clientId: SPEEDY_SENDER_CLIENT_ID,
     serviceId: SPEEDY_SERVICE_ID,
+    dropoffOfficeId,
   };
 }
 

--- a/lib/delivery/speedy/shipments.ts
+++ b/lib/delivery/speedy/shipments.ts
@@ -37,6 +37,10 @@ export interface OrderForShipment {
   userEmail: string;
   userPhone: string;
   readableId?: string;
+  /** Box price in EUR (excluding delivery fee) */
+  finalPriceEur: number;
+  /** Delivery fee in EUR */
+  deliveryFeeEur: number;
 }
 
 export interface WaybillResult {
@@ -57,10 +61,10 @@ export interface WaybillResult {
 // ============================================================================
 
 const FALLBACK_PARCEL = {
-  weight: 2.5,
-  size: { width: 30, depth: 30, height: 15 },
-  contents: 'Фитнес кутия',
-  package: 'BOX',
+  weight: 1.36,
+  size: { width: 19, depth: 26.5, height: 10 },
+  contents: 'КУТИЯ СЪС СПОРТНИ СТОКИ',
+  package: 'КАШОН',
 };
 
 interface ParcelConfig {
@@ -82,7 +86,7 @@ async function getParcelConfig(): Promise<ParcelConfig> {
         height: parseFloat(configMap.PARCEL_HEIGHT_CM ?? '') || FALLBACK_PARCEL.size.height,
       },
       contents: configMap.PARCEL_CONTENTS || FALLBACK_PARCEL.contents,
-      package: FALLBACK_PARCEL.package,
+      package: configMap.PARCEL_PACKAGE || FALLBACK_PARCEL.package,
     };
   } catch {
     return FALLBACK_PARCEL;
@@ -98,7 +102,7 @@ async function getParcelConfig(): Promise<ParcelConfig> {
  */
 export async function createWaybillForOrder(order: OrderForShipment): Promise<WaybillResult> {
   const parcel = await getParcelConfig();
-  const params = buildShipmentRequest(order, parcel);
+  const params = await buildShipmentRequest(order, parcel);
   const response = await createShipment(params);
 
   return {
@@ -113,18 +117,32 @@ export async function createWaybillForOrder(order: OrderForShipment): Promise<Wa
 /**
  * Build Speedy shipment params from a FitFlow order.
  */
-export function buildShipmentRequest(order: OrderForShipment, parcel: ParcelConfig = FALLBACK_PARCEL): CreateShipmentParams {
-  const config = getSpeedySenderConfig();
+export async function buildShipmentRequest(order: OrderForShipment, parcel: ParcelConfig = FALLBACK_PARCEL): Promise<CreateShipmentParams> {
+  const config = await getSpeedySenderConfig();
   const recipient = buildRecipient(order);
+
+  // COD amount = box price + delivery fee (what the customer pays on delivery)
+  const codAmountEur = order.finalPriceEur + order.deliveryFeeEur;
 
   return {
     sender: {
       clientId: config.clientId,
+      dropoffOfficeId: config.dropoffOfficeId,
     },
     recipient,
     service: {
       serviceId: config.serviceId,
       autoAdjustPickupDate: true,
+      additionalServices: {
+        cod: {
+          amount: codAmountEur,
+          processingType: 'CASH',
+        },
+        declaredValue: {
+          amount: codAmountEur,
+          fragile: true,
+        },
+      },
     },
     content: {
       parcelsCount: 1,
@@ -142,6 +160,7 @@ export function buildShipmentRequest(order: OrderForShipment, parcel: ParcelConf
     },
     payment: {
       courierServicePayer: 'SENDER',
+      declaredValuePayer: 'SENDER',
     },
     ref1: order.readableId || order.id,
   };


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Issues #232, #234

---

## Type of change
- [x] Bug fix
- [x] Feature
- [ ] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
This PR fixes Speedy waybill generation which was missing critical fields - cash-on-delivery, declared value, sender dropoff office, and accurate parcel dimensions/packaging - causing incomplete shipments. It also makes all parcel and dropoff settings configurable through the admin Dispatch settings page. Additionally, admins can now create a new delivery address directly from the subscription address picker modal without navigating away, with the form pre-filling customer name and phone and correctly handling the default-address flag to avoid duplicates.

---

## Target branch checklist
- [ ] dev → feature work
- [x] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [ ] This PR does NOT bump versions (required unless targeting main)
- [x] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [x] Tested on Vercel preview (if applicable)
