### PR TITLE
[DEV] Centralize address create/update logic and fix admin Speedy automat handling

### DIFF
--- a/.changeset/fair-address-automat.md
+++ b/.changeset/fair-address-automat.md
@@ -1,0 +1,7 @@
+---
+"fitflow": patch
+---
+
+Fix Speedy automat addresses not being handled in the admin address routes and centralize all address create/update logic in a shared `lib/order/address-write` module
+
+Staff creating or editing a delivery address on behalf of a customer can now correctly save Speedy automat (parcel locker) addresses; previously the admin address endpoints only recognized Speedy office and treated automat selections as an incomplete street address, causing validation errors or wrong data. Sanitization, validation, delivery-method branching, and DB payload building are now shared across the customer and admin address routes, so all delivery methods stay consistent and cannot drift out of sync again.

--- a/app/api/address/[id]/route.ts
+++ b/app/api/address/[id]/route.ts
@@ -6,12 +6,14 @@ import {
   deleteAddress,
   setDefaultAddress,
 } from '@/lib/data';
-import { validateAddress, validateSpeedyOffice } from '@/lib/order';
-import type { SpeedyOfficeSelection } from '@/lib/order';
-import { isValidPhone } from '@/lib/catalog';
 import { checkRateLimit } from '@/lib/utils/rateLimit';
-import { validateFieldLengths, sanitizeAddressBody } from '../route';
-import type { AddressUpdate } from '@/lib/supabase/types';
+import {
+  sanitizeAddressBody,
+  validateFieldLengths,
+  validatePhone,
+  validateAddressDomain,
+  buildAddressUpdate,
+} from '@/lib/order/address-write';
 
 /** Rate limit: 20 requests per minute */
 const RATE_LIMIT_MAX = 20;
@@ -101,135 +103,25 @@ export async function PUT(
     }
 
     // Phone validation (required for all delivery methods)
-    if (!sanitized.phone?.trim()) {
+    const phoneErrors = validatePhone(sanitized.phone);
+    if (phoneErrors.length > 0) {
       return NextResponse.json(
-        {
-          error: 'Невалидни данни',
-          details: [{ field: 'phone', message: 'Телефонният номер е задължителен', code: 'required' }],
-        },
+        { error: 'Невалидни данни', details: phoneErrors },
         { status: 400 },
       );
     }
-    if (!isValidPhone(sanitized.phone)) {
-      return NextResponse.json(
-        {
-          error: 'Невалидни данни',
-          details: [
-            {
-              field: 'phone',
-              message:
-                'Моля, въведете само цифри и символи за форматиране (+, -, (, ), интервал)',
-              code: 'invalid_format',
-            },
-          ],
-        },
-        { status: 400 },
-      );
-    }
-
-    const deliveryMethod = sanitized.deliveryMethod ?? 'address';
 
     // Domain validation - conditional on delivery method
-    if (deliveryMethod === 'speedy_office' || deliveryMethod === 'speedy_automat') {
-      const officeSelection: SpeedyOfficeSelection | null =
-        sanitized.speedyOfficeId && sanitized.speedyOfficeName
-          ? {
-              id: sanitized.speedyOfficeId,
-              name: sanitized.speedyOfficeName,
-              address: sanitized.speedyOfficeAddress ?? '',
-            }
-          : null;
-
-      const validationResult = validateSpeedyOffice(
-        {
-          label: sanitized.label ?? '',
-          firstName: sanitized.firstName ?? '',
-          lastName: sanitized.lastName ?? '',
-          phone: sanitized.phone ?? '',
-          city: '',
-          postalCode: '',
-          streetAddress: '',
-          buildingEntrance: '',
-          floor: '',
-          apartment: '',
-          deliveryNotes: sanitized.deliveryNotes ?? '',
-          isDefault: sanitized.isDefault ?? false,
-        },
-        officeSelection,
+    const validationResult = validateAddressDomain(sanitized);
+    if (!validationResult.valid) {
+      return NextResponse.json(
+        { error: 'Невалидни данни', details: validationResult.errors },
+        { status: 400 },
       );
-
-      if (!validationResult.valid) {
-        return NextResponse.json(
-          { error: 'Невалидни данни', details: validationResult.errors },
-          { status: 400 },
-        );
-      }
-    } else {
-      const validationResult = validateAddress({
-        label: sanitized.label ?? '',
-        firstName: sanitized.firstName ?? '',
-        lastName: sanitized.lastName ?? '',
-        phone: sanitized.phone ?? '',
-        city: sanitized.city ?? '',
-        postalCode: sanitized.postalCode ?? '',
-        streetAddress: sanitized.streetAddress ?? '',
-        buildingEntrance: sanitized.buildingEntrance ?? '',
-        floor: sanitized.floor ?? '',
-        apartment: sanitized.apartment ?? '',
-        deliveryNotes: sanitized.deliveryNotes ?? '',
-        isDefault: sanitized.isDefault ?? false,
-      });
-
-      if (!validationResult.valid) {
-        return NextResponse.json(
-          { error: 'Невалидни данни', details: validationResult.errors },
-          { status: 400 },
-        );
-      }
     }
 
-    // Build update payload - conditional on delivery method
-    // When switching method, explicitly null out fields that no longer apply
-    const updateData: AddressUpdate =
-      deliveryMethod === 'speedy_office' || deliveryMethod === 'speedy_automat'
-        ? {
-            delivery_method: deliveryMethod,
-            first_name: sanitized.firstName!,
-            last_name: sanitized.lastName!,
-            phone: sanitized.phone || null,
-            speedy_office_id: sanitized.speedyOfficeId!,
-            speedy_office_name: sanitized.speedyOfficeName!,
-            speedy_office_address: sanitized.speedyOfficeAddress || null,
-            label: sanitized.label || null,
-            delivery_notes: sanitized.deliveryNotes || null,
-            is_default: sanitized.isDefault ?? false,
-            // Null out home-delivery fields
-            city: null,
-            postal_code: null,
-            street_address: null,
-            building_entrance: null,
-            floor: null,
-            apartment: null,
-          }
-        : {
-            delivery_method: 'address',
-            first_name: sanitized.firstName!,
-            last_name: sanitized.lastName!,
-            city: sanitized.city!,
-            postal_code: sanitized.postalCode!,
-            street_address: sanitized.streetAddress!,
-            label: sanitized.label || null,
-            phone: sanitized.phone || null,
-            building_entrance: sanitized.buildingEntrance || null,
-            floor: sanitized.floor || null,
-            apartment: sanitized.apartment || null,
-            delivery_notes: sanitized.deliveryNotes || null,
-            is_default: sanitized.isDefault ?? false,
-            // Null out Speedy fields
-            speedy_office_id: null,
-            speedy_office_name: null,
-            speedy_office_address: null,
-          };
+    // Build update payload - nulls out inapplicable fields when switching method
+    const updateData = buildAddressUpdate(sanitized);
 
     try {
       const address = await updateAddress(id, session.userId, updateData);

--- a/app/api/address/route.ts
+++ b/app/api/address/route.ts
@@ -4,29 +4,17 @@ import {
   getAddressesByUser,
   createAddress,
   countAddressesByUser,
+  syncPhoneToProfile,
 } from '@/lib/data';
-import { validateAddress, validateSpeedyOffice } from '@/lib/order';
-import type { SpeedyOfficeSelection } from '@/lib/order';
-import { isValidPhone } from '@/lib/catalog';
+import {
+  MAX_ADDRESSES,
+  sanitizeAddressBody,
+  validateFieldLengths,
+  validatePhone,
+  validateAddressDomain,
+  buildAddressInsert,
+} from '@/lib/order/address-write';
 import { checkRateLimit } from '@/lib/utils/rateLimit';
-import { supabaseAdmin } from '@/lib/supabase/admin';
-import type { AddressInsert } from '@/lib/supabase/types';
-
-// Field length limits
-const MAX_FIRST_NAME = 100;
-const MAX_LAST_NAME = 100;
-const MAX_CITY = 100;
-const MAX_STREET = 500;
-const MAX_LABEL = 50;
-const MAX_OPTIONAL_FIELD = 50; // buildingEntrance, floor, apartment
-const MAX_DELIVERY_NOTES = 500;
-const MAX_SPEEDY_OFFICE_NAME = 200;
-const MAX_SPEEDY_OFFICE_ADDRESS = 500;
-const MAX_SPEEDY_OFFICE_ID = 100;
-const MAX_ADDRESSES = 10;
-
-const VALID_DELIVERY_METHODS = ['address', 'speedy_office', 'speedy_automat'] as const;
-type DeliveryMethodValue = (typeof VALID_DELIVERY_METHODS)[number];
 
 /** Rate limit: 20 requests per minute */
 const RATE_LIMIT_MAX = 20;
@@ -109,127 +97,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     // Phone validation (required for all delivery methods)
-    if (!sanitized.phone?.trim()) {
+    const phoneErrors = validatePhone(sanitized.phone);
+    if (phoneErrors.length > 0) {
       return NextResponse.json(
-        {
-          error: 'Невалидни данни',
-          details: [{ field: 'phone', message: 'Телефонният номер е задължителен', code: 'required' }],
-        },
+        { error: 'Невалидни данни', details: phoneErrors },
         { status: 400 },
       );
     }
-    if (!isValidPhone(sanitized.phone)) {
-      return NextResponse.json(
-        {
-          error: 'Невалидни данни',
-          details: [
-            {
-              field: 'phone',
-              message:
-                'Моля, въведете само цифри и символи за форматиране (+, -, (, ), интервал)',
-              code: 'invalid_format',
-            },
-          ],
-        },
-        { status: 400 },
-      );
-    }
-
-    const deliveryMethod = sanitized.deliveryMethod ?? 'address';
 
     // Domain validation - conditional on delivery method
-    if (deliveryMethod === 'speedy_office' || deliveryMethod === 'speedy_automat') {
-      const officeSelection: SpeedyOfficeSelection | null =
-        sanitized.speedyOfficeId && sanitized.speedyOfficeName
-          ? {
-              id: sanitized.speedyOfficeId,
-              name: sanitized.speedyOfficeName,
-              address: sanitized.speedyOfficeAddress ?? '',
-            }
-          : null;
-
-      const validationResult = validateSpeedyOffice(
-        {
-          label: sanitized.label ?? '',
-          firstName: sanitized.firstName ?? '',
-          lastName: sanitized.lastName ?? '',
-          phone: sanitized.phone ?? '',
-          city: '',
-          postalCode: '',
-          streetAddress: '',
-          buildingEntrance: '',
-          floor: '',
-          apartment: '',
-          deliveryNotes: sanitized.deliveryNotes ?? '',
-          isDefault: sanitized.isDefault ?? false,
-        },
-        officeSelection,
+    const validationResult = validateAddressDomain(sanitized);
+    if (!validationResult.valid) {
+      return NextResponse.json(
+        { error: 'Невалидни данни', details: validationResult.errors },
+        { status: 400 },
       );
-
-      if (!validationResult.valid) {
-        return NextResponse.json(
-          { error: 'Невалидни данни', details: validationResult.errors },
-          { status: 400 },
-        );
-      }
-    } else {
-      const validationResult = validateAddress({
-        label: sanitized.label ?? '',
-        firstName: sanitized.firstName ?? '',
-        lastName: sanitized.lastName ?? '',
-        phone: sanitized.phone ?? '',
-        city: sanitized.city ?? '',
-        postalCode: sanitized.postalCode ?? '',
-        streetAddress: sanitized.streetAddress ?? '',
-        buildingEntrance: sanitized.buildingEntrance ?? '',
-        floor: sanitized.floor ?? '',
-        apartment: sanitized.apartment ?? '',
-        deliveryNotes: sanitized.deliveryNotes ?? '',
-        isDefault: sanitized.isDefault ?? false,
-      });
-
-      if (!validationResult.valid) {
-        return NextResponse.json(
-          { error: 'Невалидни данни', details: validationResult.errors },
-          { status: 400 },
-        );
-      }
     }
 
-    // Build insert payload - conditional on delivery method
-    const autoLabel = generateAddressLabel(deliveryMethod, sanitized);
-
-    const insertData: AddressInsert =
-      deliveryMethod === 'speedy_office' || deliveryMethod === 'speedy_automat'
-        ? {
-            user_id: session.userId,
-            delivery_method: deliveryMethod,
-            first_name: sanitized.firstName!,
-            last_name: sanitized.lastName!,
-            phone: sanitized.phone || null,
-            speedy_office_id: sanitized.speedyOfficeId!,
-            speedy_office_name: sanitized.speedyOfficeName!,
-            speedy_office_address: sanitized.speedyOfficeAddress || null,
-            label: autoLabel,
-            delivery_notes: sanitized.deliveryNotes || null,
-            is_default: sanitized.isDefault ?? false,
-          }
-        : {
-            user_id: session.userId,
-            delivery_method: 'address',
-            first_name: sanitized.firstName!,
-            last_name: sanitized.lastName!,
-            city: sanitized.city!,
-            postal_code: sanitized.postalCode!,
-            street_address: sanitized.streetAddress!,
-            label: autoLabel,
-            phone: sanitized.phone || null,
-            building_entrance: sanitized.buildingEntrance || null,
-            floor: sanitized.floor || null,
-            apartment: sanitized.apartment || null,
-            delivery_notes: sanitized.deliveryNotes || null,
-            is_default: sanitized.isDefault ?? false,
-          };
+    // Build insert payload
+    const insertData = buildAddressInsert(session.userId, sanitized);
 
     const address = await createAddress(insertData);
 
@@ -251,210 +137,4 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { status: 500 },
     );
   }
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-export interface SanitizedBody {
-  deliveryMethod?: DeliveryMethodValue;
-  label?: string;
-  firstName?: string;
-  lastName?: string;
-  phone?: string;
-  city?: string;
-  postalCode?: string;
-  streetAddress?: string;
-  buildingEntrance?: string;
-  floor?: string;
-  apartment?: string;
-  deliveryNotes?: string;
-  isDefault?: boolean;
-  speedyOfficeId?: string;
-  speedyOfficeName?: string;
-  speedyOfficeAddress?: string;
-}
-
-/**
- * Trim all string fields from the request body.
- */
-export function sanitizeAddressBody(body: Record<string, unknown>): SanitizedBody {
-  const trimStr = (v: unknown): string | undefined =>
-    typeof v === 'string' ? v.trim() : undefined;
-
-  const rawMethod = trimStr(body.deliveryMethod);
-  const deliveryMethod: DeliveryMethodValue =
-    rawMethod && (VALID_DELIVERY_METHODS as readonly string[]).includes(rawMethod)
-      ? (rawMethod as DeliveryMethodValue)
-      : 'address';
-
-  return {
-    deliveryMethod,
-    label: trimStr(body.label),
-    firstName: trimStr(body.firstName),
-    lastName: trimStr(body.lastName),
-    phone: trimStr(body.phone),
-    city: trimStr(body.city),
-    postalCode: trimStr(body.postalCode),
-    streetAddress: trimStr(body.streetAddress),
-    buildingEntrance: trimStr(body.buildingEntrance),
-    floor: trimStr(body.floor),
-    apartment: trimStr(body.apartment),
-    deliveryNotes: trimStr(body.deliveryNotes),
-    isDefault: typeof body.isDefault === 'boolean' ? body.isDefault : undefined,
-    speedyOfficeId: trimStr(body.speedyOfficeId),
-    speedyOfficeName: trimStr(body.speedyOfficeName),
-    speedyOfficeAddress: trimStr(body.speedyOfficeAddress),
-  };
-}
-
-/**
- * Validate max lengths for all fields. Returns array of errors (empty if valid).
- */
-export function validateFieldLengths(
-  data: SanitizedBody,
-): Array<{ field: string; message: string; code: string }> {
-  const errors: Array<{ field: string; message: string; code: string }> = [];
-
-  if (data.firstName && data.firstName.length > MAX_FIRST_NAME) {
-    errors.push({
-      field: 'firstName',
-      message: `Името трябва да е най-много ${MAX_FIRST_NAME} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.lastName && data.lastName.length > MAX_LAST_NAME) {
-    errors.push({
-      field: 'lastName',
-      message: `Фамилията трябва да е най-много ${MAX_LAST_NAME} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.city && data.city.length > MAX_CITY) {
-    errors.push({
-      field: 'city',
-      message: `Градът трябва да е най-много ${MAX_CITY} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.streetAddress && data.streetAddress.length > MAX_STREET) {
-    errors.push({
-      field: 'streetAddress',
-      message: `Адресът трябва да е най-много ${MAX_STREET} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.label && data.label.length > MAX_LABEL) {
-    errors.push({
-      field: 'label',
-      message: `Етикетът трябва да е най-много ${MAX_LABEL} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.buildingEntrance && data.buildingEntrance.length > MAX_OPTIONAL_FIELD) {
-    errors.push({
-      field: 'buildingEntrance',
-      message: `Входът трябва да е най-много ${MAX_OPTIONAL_FIELD} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.floor && data.floor.length > MAX_OPTIONAL_FIELD) {
-    errors.push({
-      field: 'floor',
-      message: `Етажът трябва да е най-много ${MAX_OPTIONAL_FIELD} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.apartment && data.apartment.length > MAX_OPTIONAL_FIELD) {
-    errors.push({
-      field: 'apartment',
-      message: `Апартаментът трябва да е най-много ${MAX_OPTIONAL_FIELD} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.deliveryNotes && data.deliveryNotes.length > MAX_DELIVERY_NOTES) {
-    errors.push({
-      field: 'deliveryNotes',
-      message: `Бележките трябва да са най-много ${MAX_DELIVERY_NOTES} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.speedyOfficeName && data.speedyOfficeName.length > MAX_SPEEDY_OFFICE_NAME) {
-    errors.push({
-      field: 'speedyOfficeName',
-      message: `Името на офиса трябва да е най-много ${MAX_SPEEDY_OFFICE_NAME} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.speedyOfficeAddress && data.speedyOfficeAddress.length > MAX_SPEEDY_OFFICE_ADDRESS) {
-    errors.push({
-      field: 'speedyOfficeAddress',
-      message: `Адресът на офиса трябва да е най-много ${MAX_SPEEDY_OFFICE_ADDRESS} символа`,
-      code: 'too_long',
-    });
-  }
-
-  if (data.speedyOfficeId && data.speedyOfficeId.length > MAX_SPEEDY_OFFICE_ID) {
-    errors.push({
-      field: 'speedyOfficeId',
-      message: `ID на офиса трябва да е най-много ${MAX_SPEEDY_OFFICE_ID} символа`,
-      code: 'too_long',
-    });
-  }
-
-  return errors;
-}
-
-/**
- * Auto-generate address label when none provided.
- */
-export function generateAddressLabel(
-  deliveryMethod: string,
-  sanitized: SanitizedBody,
-): string | null {
-  if (sanitized.label) return sanitized.label;
-
-  if (deliveryMethod === 'speedy_office' || deliveryMethod === 'speedy_automat') {
-    return (sanitized.speedyOfficeName ?? 'Speedy офис').slice(0, MAX_LABEL);
-  }
-
-  const city = sanitized.city ?? '';
-  const street = sanitized.streetAddress ?? '';
-  if (city && street) {
-    return `${city} - ${street}`.slice(0, MAX_LABEL);
-  }
-
-  return null;
-}
-
-/**
- * If the user profile has no phone, copy the address phone to the profile.
- * Returns true if the phone was synced.
- */
-export async function syncPhoneToProfile(userId: string, phone: string): Promise<boolean> {
-  const { data: profile } = await supabaseAdmin
-    .from('user_profiles')
-    .select('phone')
-    .eq('id', userId)
-    .single();
-
-  if (profile && !profile.phone?.trim()) {
-    await supabaseAdmin
-      .from('user_profiles')
-      .update({ phone })
-      .eq('id', userId);
-    return true;
-  }
-  return false;
 }

--- a/app/api/admin/address/[id]/route.ts
+++ b/app/api/admin/address/[id]/route.ts
@@ -7,15 +7,14 @@ import {
   updateAddressAdmin,
   deleteAddressAdmin,
 } from '@/lib/data';
-import { validateAddress, validateSpeedyOffice } from '@/lib/order';
-import type { SpeedyOfficeSelection } from '@/lib/order';
-import { isValidPhone } from '@/lib/catalog';
 import { checkRateLimit } from '@/lib/utils/rateLimit';
 import {
   sanitizeAddressBody,
   validateFieldLengths,
-} from '@/app/api/address/route';
-import type { AddressUpdate } from '@/lib/supabase/types';
+  validatePhone,
+  validateAddressDomain,
+  buildAddressUpdate,
+} from '@/lib/order/address-write';
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -153,134 +152,25 @@ export async function PUT(
     }
 
     // Phone validation (required for all delivery methods)
-    if (!sanitized.phone?.trim()) {
+    const phoneErrors = validatePhone(sanitized.phone);
+    if (phoneErrors.length > 0) {
       return NextResponse.json(
-        {
-          error: 'Невалидни данни',
-          details: [{ field: 'phone', message: 'Телефонният номер е задължителен', code: 'required' }],
-        },
+        { error: 'Невалидни данни', details: phoneErrors },
         { status: 400 },
       );
     }
-    if (!isValidPhone(sanitized.phone)) {
-      return NextResponse.json(
-        {
-          error: 'Невалидни данни',
-          details: [
-            {
-              field: 'phone',
-              message:
-                'Моля, въведете само цифри и символи за форматиране (+, -, (, ), интервал)',
-              code: 'invalid_format',
-            },
-          ],
-        },
-        { status: 400 },
-      );
-    }
-
-    const deliveryMethod = sanitized.deliveryMethod ?? 'address';
 
     // Domain validation - conditional on delivery method
-    if (deliveryMethod === 'speedy_office') {
-      const officeSelection: SpeedyOfficeSelection | null =
-        sanitized.speedyOfficeId && sanitized.speedyOfficeName
-          ? {
-              id: sanitized.speedyOfficeId,
-              name: sanitized.speedyOfficeName,
-              address: sanitized.speedyOfficeAddress ?? '',
-            }
-          : null;
-
-      const validationResult = validateSpeedyOffice(
-        {
-          label: sanitized.label ?? '',
-          firstName: sanitized.firstName ?? '',
-          lastName: sanitized.lastName ?? '',
-          phone: sanitized.phone ?? '',
-          city: '',
-          postalCode: '',
-          streetAddress: '',
-          buildingEntrance: '',
-          floor: '',
-          apartment: '',
-          deliveryNotes: sanitized.deliveryNotes ?? '',
-          isDefault: sanitized.isDefault ?? false,
-        },
-        officeSelection,
+    const validationResult = validateAddressDomain(sanitized);
+    if (!validationResult.valid) {
+      return NextResponse.json(
+        { error: 'Невалидни данни', details: validationResult.errors },
+        { status: 400 },
       );
-
-      if (!validationResult.valid) {
-        return NextResponse.json(
-          { error: 'Невалидни данни', details: validationResult.errors },
-          { status: 400 },
-        );
-      }
-    } else {
-      const validationResult = validateAddress({
-        label: sanitized.label ?? '',
-        firstName: sanitized.firstName ?? '',
-        lastName: sanitized.lastName ?? '',
-        phone: sanitized.phone ?? '',
-        city: sanitized.city ?? '',
-        postalCode: sanitized.postalCode ?? '',
-        streetAddress: sanitized.streetAddress ?? '',
-        buildingEntrance: sanitized.buildingEntrance ?? '',
-        floor: sanitized.floor ?? '',
-        apartment: sanitized.apartment ?? '',
-        deliveryNotes: sanitized.deliveryNotes ?? '',
-        isDefault: sanitized.isDefault ?? false,
-      });
-
-      if (!validationResult.valid) {
-        return NextResponse.json(
-          { error: 'Невалидни данни', details: validationResult.errors },
-          { status: 400 },
-        );
-      }
     }
 
-    // Build update payload - null out inapplicable fields when switching method
-    const updateData: AddressUpdate =
-      deliveryMethod === 'speedy_office'
-        ? {
-            delivery_method: 'speedy_office',
-            first_name: sanitized.firstName!,
-            last_name: sanitized.lastName!,
-            phone: sanitized.phone || null,
-            speedy_office_id: sanitized.speedyOfficeId!,
-            speedy_office_name: sanitized.speedyOfficeName!,
-            speedy_office_address: sanitized.speedyOfficeAddress || null,
-            label: sanitized.label || null,
-            delivery_notes: sanitized.deliveryNotes || null,
-            is_default: sanitized.isDefault ?? false,
-            // Null out home-delivery fields
-            city: null,
-            postal_code: null,
-            street_address: null,
-            building_entrance: null,
-            floor: null,
-            apartment: null,
-          }
-        : {
-            delivery_method: 'address',
-            first_name: sanitized.firstName!,
-            last_name: sanitized.lastName!,
-            city: sanitized.city!,
-            postal_code: sanitized.postalCode!,
-            street_address: sanitized.streetAddress!,
-            label: sanitized.label || null,
-            phone: sanitized.phone || null,
-            building_entrance: sanitized.buildingEntrance || null,
-            floor: sanitized.floor || null,
-            apartment: sanitized.apartment || null,
-            delivery_notes: sanitized.deliveryNotes || null,
-            is_default: sanitized.isDefault ?? false,
-            // Null out Speedy fields
-            speedy_office_id: null,
-            speedy_office_name: null,
-            speedy_office_address: null,
-          };
+    // Build update payload - nulls out inapplicable fields when switching method
+    const updateData = buildAddressUpdate(sanitized);
 
     const address = await updateAddressAdmin(id, updateData);
     return NextResponse.json({ address });

--- a/app/api/admin/address/route.ts
+++ b/app/api/admin/address/route.ts
@@ -2,24 +2,26 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { headers } from 'next/headers';
 import { verifySession } from '@/lib/auth';
 import { CUSTOMER_VIEW_ROLES, STAFF_MANAGEMENT_ROLES } from '@/lib/auth/permissions';
-import { getAddressesByUser, createAddress, countAddressesByUser } from '@/lib/data';
-import { validateAddress, validateSpeedyOffice } from '@/lib/order';
-import type { SpeedyOfficeSelection } from '@/lib/order';
-import { isValidPhone } from '@/lib/catalog';
-import { checkRateLimit } from '@/lib/utils/rateLimit';
-import { supabaseAdmin } from '@/lib/supabase/admin';
 import {
+  getAddressesByUser,
+  createAddress,
+  countAddressesByUser,
+  syncPhoneToProfile,
+  unsetDefaultAddresses,
+} from '@/lib/data';
+import {
+  MAX_ADDRESSES,
   sanitizeAddressBody,
   validateFieldLengths,
-  generateAddressLabel,
-  syncPhoneToProfile,
-} from '@/app/api/address/route';
-import type { AddressInsert } from '@/lib/supabase/types';
+  validatePhone,
+  validateAddressDomain,
+  buildAddressInsert,
+} from '@/lib/order/address-write';
+import { checkRateLimit } from '@/lib/utils/rateLimit';
+import { supabaseAdmin } from '@/lib/supabase/admin';
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-const MAX_ADDRESSES = 10;
 
 // ============================================================================
 // GET /api/admin/address?userId=<uuid> - List addresses for a user
@@ -154,135 +156,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     // Phone validation (required for all delivery methods)
-    if (!sanitized.phone?.trim()) {
+    const phoneErrors = validatePhone(sanitized.phone);
+    if (phoneErrors.length > 0) {
       return NextResponse.json(
-        {
-          error: 'Невалидни данни',
-          details: [{ field: 'phone', message: 'Телефонният номер е задължителен', code: 'required' }],
-        },
+        { error: 'Невалидни данни', details: phoneErrors },
         { status: 400 },
       );
     }
-    if (!isValidPhone(sanitized.phone)) {
-      return NextResponse.json(
-        {
-          error: 'Невалидни данни',
-          details: [
-            {
-              field: 'phone',
-              message:
-                'Моля, въведете само цифри и символи за форматиране (+, -, (, ), интервал)',
-              code: 'invalid_format',
-            },
-          ],
-        },
-        { status: 400 },
-      );
-    }
-
-    const deliveryMethod = sanitized.deliveryMethod ?? 'address';
 
     // Domain validation - conditional on delivery method
-    if (deliveryMethod === 'speedy_office') {
-      const officeSelection: SpeedyOfficeSelection | null =
-        sanitized.speedyOfficeId && sanitized.speedyOfficeName
-          ? {
-              id: sanitized.speedyOfficeId,
-              name: sanitized.speedyOfficeName,
-              address: sanitized.speedyOfficeAddress ?? '',
-            }
-          : null;
-
-      const validationResult = validateSpeedyOffice(
-        {
-          label: sanitized.label ?? '',
-          firstName: sanitized.firstName ?? '',
-          lastName: sanitized.lastName ?? '',
-          phone: sanitized.phone ?? '',
-          city: '',
-          postalCode: '',
-          streetAddress: '',
-          buildingEntrance: '',
-          floor: '',
-          apartment: '',
-          deliveryNotes: sanitized.deliveryNotes ?? '',
-          isDefault: sanitized.isDefault ?? false,
-        },
-        officeSelection,
+    const validationResult = validateAddressDomain(sanitized);
+    if (!validationResult.valid) {
+      return NextResponse.json(
+        { error: 'Невалидни данни', details: validationResult.errors },
+        { status: 400 },
       );
-
-      if (!validationResult.valid) {
-        return NextResponse.json(
-          { error: 'Невалидни данни', details: validationResult.errors },
-          { status: 400 },
-        );
-      }
-    } else {
-      const validationResult = validateAddress({
-        label: sanitized.label ?? '',
-        firstName: sanitized.firstName ?? '',
-        lastName: sanitized.lastName ?? '',
-        phone: sanitized.phone ?? '',
-        city: sanitized.city ?? '',
-        postalCode: sanitized.postalCode ?? '',
-        streetAddress: sanitized.streetAddress ?? '',
-        buildingEntrance: sanitized.buildingEntrance ?? '',
-        floor: sanitized.floor ?? '',
-        apartment: sanitized.apartment ?? '',
-        deliveryNotes: sanitized.deliveryNotes ?? '',
-        isDefault: sanitized.isDefault ?? false,
-      });
-
-      if (!validationResult.valid) {
-        return NextResponse.json(
-          { error: 'Невалидни данни', details: validationResult.errors },
-          { status: 400 },
-        );
-      }
     }
 
     // Build insert payload - use target userId, not session userId
-    const autoLabel = generateAddressLabel(deliveryMethod, sanitized);
-
-    const insertData: AddressInsert =
-      deliveryMethod === 'speedy_office'
-        ? {
-            user_id: userId,
-            delivery_method: 'speedy_office',
-            first_name: sanitized.firstName!,
-            last_name: sanitized.lastName!,
-            phone: sanitized.phone || null,
-            speedy_office_id: sanitized.speedyOfficeId!,
-            speedy_office_name: sanitized.speedyOfficeName!,
-            speedy_office_address: sanitized.speedyOfficeAddress || null,
-            label: autoLabel,
-            delivery_notes: sanitized.deliveryNotes || null,
-            is_default: sanitized.isDefault ?? false,
-          }
-        : {
-            user_id: userId,
-            delivery_method: 'address',
-            first_name: sanitized.firstName!,
-            last_name: sanitized.lastName!,
-            city: sanitized.city!,
-            postal_code: sanitized.postalCode!,
-            street_address: sanitized.streetAddress!,
-            label: autoLabel,
-            phone: sanitized.phone || null,
-            building_entrance: sanitized.buildingEntrance || null,
-            floor: sanitized.floor || null,
-            apartment: sanitized.apartment || null,
-            delivery_notes: sanitized.deliveryNotes || null,
-            is_default: sanitized.isDefault ?? false,
-          };
+    const insertData = buildAddressInsert(userId, sanitized);
 
     // Explicitly unset other defaults before insert (defense against trigger edge cases)
     if (insertData.is_default) {
-      await supabaseAdmin
-        .from('addresses')
-        .update({ is_default: false })
-        .eq('user_id', userId)
-        .eq('is_default', true);
+      await unsetDefaultAddresses(userId);
     }
 
     const address = await createAddress(insertData);

--- a/lib/data/addresses.ts
+++ b/lib/data/addresses.ts
@@ -251,3 +251,33 @@ export async function setDefaultAddress(addressId: string, userId: string): Prom
     throw new Error('Address not found or does not belong to this user.');
   }
 }
+
+/**
+ * If the user profile has no phone, copy the address phone to the profile.
+ * Returns true if the phone was synced.
+ */
+export async function syncPhoneToProfile(userId: string, phone: string): Promise<boolean> {
+  const { data: profile } = await supabaseAdmin
+    .from('user_profiles')
+    .select('phone')
+    .eq('id', userId)
+    .single();
+
+  if (profile && !profile.phone?.trim()) {
+    await supabaseAdmin.from('user_profiles').update({ phone }).eq('id', userId);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Unset all default addresses for a user. Defense against trigger edge cases
+ * before inserting a new default address.
+ */
+export async function unsetDefaultAddresses(userId: string): Promise<void> {
+  await supabaseAdmin
+    .from('addresses')
+    .update({ is_default: false })
+    .eq('user_id', userId)
+    .eq('is_default', true);
+}

--- a/lib/data/index.ts
+++ b/lib/data/index.ts
@@ -61,6 +61,8 @@ export {
   getAddressByIdAdmin,
   updateAddressAdmin,
   deleteAddressAdmin,
+  syncPhoneToProfile,
+  unsetDefaultAddresses,
 } from './addresses';
 
 // Order data

--- a/lib/order/address-write.ts
+++ b/lib/order/address-write.ts
@@ -1,0 +1,400 @@
+/**
+ * Address Write Helpers
+ *
+ * Shared server-side logic for creating and updating addresses across the
+ * customer (`/api/address`) and admin (`/api/admin/address`) routes.
+ *
+ * Pure module — no DB access, so it stays test- and client-friendly.
+ * DB-touching helpers (e.g. syncPhoneToProfile) live in `@/lib/data`.
+ */
+
+import { validateAddress, validateSpeedyOffice } from './validation';
+import type { SpeedyOfficeSelection } from './types';
+import { isValidPhone } from '@/lib/catalog';
+import type { ValidationError } from '@/lib/catalog';
+import type { AddressInsert, AddressUpdate } from '@/lib/supabase/types';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// Field length limits
+const MAX_FIRST_NAME = 100;
+const MAX_LAST_NAME = 100;
+const MAX_CITY = 100;
+const MAX_STREET = 500;
+const MAX_LABEL = 50;
+const MAX_OPTIONAL_FIELD = 50; // buildingEntrance, floor, apartment
+const MAX_DELIVERY_NOTES = 500;
+const MAX_SPEEDY_OFFICE_NAME = 200;
+const MAX_SPEEDY_OFFICE_ADDRESS = 500;
+const MAX_SPEEDY_OFFICE_ID = 100;
+
+/** Maximum addresses allowed per user. */
+export const MAX_ADDRESSES = 10;
+
+export const VALID_DELIVERY_METHODS = [
+  'address',
+  'speedy_office',
+  'speedy_automat',
+] as const;
+export type DeliveryMethodValue = (typeof VALID_DELIVERY_METHODS)[number];
+
+/** True for delivery methods that use a Speedy pickup point (office or automat). */
+export function isSpeedyPickup(method: DeliveryMethodValue): boolean {
+  return method === 'speedy_office' || method === 'speedy_automat';
+}
+
+// ============================================================================
+// Sanitization
+// ============================================================================
+
+export interface SanitizedBody {
+  deliveryMethod: DeliveryMethodValue;
+  label?: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  city?: string;
+  postalCode?: string;
+  streetAddress?: string;
+  buildingEntrance?: string;
+  floor?: string;
+  apartment?: string;
+  deliveryNotes?: string;
+  isDefault?: boolean;
+  speedyOfficeId?: string;
+  speedyOfficeName?: string;
+  speedyOfficeAddress?: string;
+}
+
+/**
+ * Trim all string fields from the request body and resolve the delivery method.
+ */
+export function sanitizeAddressBody(body: Record<string, unknown>): SanitizedBody {
+  const trimStr = (v: unknown): string | undefined =>
+    typeof v === 'string' ? v.trim() : undefined;
+
+  const rawMethod = trimStr(body.deliveryMethod);
+  const deliveryMethod: DeliveryMethodValue =
+    rawMethod && (VALID_DELIVERY_METHODS as readonly string[]).includes(rawMethod)
+      ? (rawMethod as DeliveryMethodValue)
+      : 'address';
+
+  return {
+    deliveryMethod,
+    label: trimStr(body.label),
+    firstName: trimStr(body.firstName),
+    lastName: trimStr(body.lastName),
+    phone: trimStr(body.phone),
+    city: trimStr(body.city),
+    postalCode: trimStr(body.postalCode),
+    streetAddress: trimStr(body.streetAddress),
+    buildingEntrance: trimStr(body.buildingEntrance),
+    floor: trimStr(body.floor),
+    apartment: trimStr(body.apartment),
+    deliveryNotes: trimStr(body.deliveryNotes),
+    isDefault: typeof body.isDefault === 'boolean' ? body.isDefault : undefined,
+    speedyOfficeId: trimStr(body.speedyOfficeId),
+    speedyOfficeName: trimStr(body.speedyOfficeName),
+    speedyOfficeAddress: trimStr(body.speedyOfficeAddress),
+  };
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Validate max lengths for all fields. Returns array of errors (empty if valid).
+ */
+export function validateFieldLengths(data: SanitizedBody): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (data.firstName && data.firstName.length > MAX_FIRST_NAME) {
+    errors.push({
+      field: 'firstName',
+      message: `Името трябва да е най-много ${MAX_FIRST_NAME} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.lastName && data.lastName.length > MAX_LAST_NAME) {
+    errors.push({
+      field: 'lastName',
+      message: `Фамилията трябва да е най-много ${MAX_LAST_NAME} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.city && data.city.length > MAX_CITY) {
+    errors.push({
+      field: 'city',
+      message: `Градът трябва да е най-много ${MAX_CITY} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.streetAddress && data.streetAddress.length > MAX_STREET) {
+    errors.push({
+      field: 'streetAddress',
+      message: `Адресът трябва да е най-много ${MAX_STREET} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.label && data.label.length > MAX_LABEL) {
+    errors.push({
+      field: 'label',
+      message: `Етикетът трябва да е най-много ${MAX_LABEL} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.buildingEntrance && data.buildingEntrance.length > MAX_OPTIONAL_FIELD) {
+    errors.push({
+      field: 'buildingEntrance',
+      message: `Входът трябва да е най-много ${MAX_OPTIONAL_FIELD} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.floor && data.floor.length > MAX_OPTIONAL_FIELD) {
+    errors.push({
+      field: 'floor',
+      message: `Етажът трябва да е най-много ${MAX_OPTIONAL_FIELD} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.apartment && data.apartment.length > MAX_OPTIONAL_FIELD) {
+    errors.push({
+      field: 'apartment',
+      message: `Апартаментът трябва да е най-много ${MAX_OPTIONAL_FIELD} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.deliveryNotes && data.deliveryNotes.length > MAX_DELIVERY_NOTES) {
+    errors.push({
+      field: 'deliveryNotes',
+      message: `Бележките трябва да са най-много ${MAX_DELIVERY_NOTES} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.speedyOfficeName && data.speedyOfficeName.length > MAX_SPEEDY_OFFICE_NAME) {
+    errors.push({
+      field: 'speedyOfficeName',
+      message: `Името на офиса трябва да е най-много ${MAX_SPEEDY_OFFICE_NAME} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.speedyOfficeAddress && data.speedyOfficeAddress.length > MAX_SPEEDY_OFFICE_ADDRESS) {
+    errors.push({
+      field: 'speedyOfficeAddress',
+      message: `Адресът на офиса трябва да е най-много ${MAX_SPEEDY_OFFICE_ADDRESS} символа`,
+      code: 'too_long',
+    });
+  }
+
+  if (data.speedyOfficeId && data.speedyOfficeId.length > MAX_SPEEDY_OFFICE_ID) {
+    errors.push({
+      field: 'speedyOfficeId',
+      message: `ID на офиса трябва да е най-много ${MAX_SPEEDY_OFFICE_ID} символа`,
+      code: 'too_long',
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Validate the phone number (required for all delivery methods).
+ * Returns array of errors (empty if valid).
+ */
+export function validatePhone(phone: string | undefined): ValidationError[] {
+  if (!phone?.trim()) {
+    return [
+      { field: 'phone', message: 'Телефонният номер е задължителен', code: 'required' },
+    ];
+  }
+  if (!isValidPhone(phone)) {
+    return [
+      {
+        field: 'phone',
+        message:
+          'Моля, въведете само цифри и символи за форматиране (+, -, (, ), интервал)',
+        code: 'invalid_format',
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Run domain validation for the resolved delivery method.
+ * Handles the address vs Speedy pickup (office/automat) branch in one place.
+ */
+export function validateAddressDomain(
+  sanitized: SanitizedBody,
+): { valid: boolean; errors: ValidationError[] } {
+  if (isSpeedyPickup(sanitized.deliveryMethod)) {
+    const officeSelection: SpeedyOfficeSelection | null =
+      sanitized.speedyOfficeId && sanitized.speedyOfficeName
+        ? {
+            id: sanitized.speedyOfficeId,
+            name: sanitized.speedyOfficeName,
+            address: sanitized.speedyOfficeAddress ?? '',
+          }
+        : null;
+
+    return validateSpeedyOffice(
+      {
+        label: sanitized.label ?? '',
+        firstName: sanitized.firstName ?? '',
+        lastName: sanitized.lastName ?? '',
+        phone: sanitized.phone ?? '',
+        city: '',
+        postalCode: '',
+        streetAddress: '',
+        buildingEntrance: '',
+        floor: '',
+        apartment: '',
+        deliveryNotes: sanitized.deliveryNotes ?? '',
+        isDefault: sanitized.isDefault ?? false,
+      },
+      officeSelection,
+    );
+  }
+
+  return validateAddress({
+    label: sanitized.label ?? '',
+    firstName: sanitized.firstName ?? '',
+    lastName: sanitized.lastName ?? '',
+    phone: sanitized.phone ?? '',
+    city: sanitized.city ?? '',
+    postalCode: sanitized.postalCode ?? '',
+    streetAddress: sanitized.streetAddress ?? '',
+    buildingEntrance: sanitized.buildingEntrance ?? '',
+    floor: sanitized.floor ?? '',
+    apartment: sanitized.apartment ?? '',
+    deliveryNotes: sanitized.deliveryNotes ?? '',
+    isDefault: sanitized.isDefault ?? false,
+  });
+}
+
+// ============================================================================
+// Persistence payload
+// ============================================================================
+
+/**
+ * Auto-generate an address label when none provided.
+ */
+export function generateAddressLabel(sanitized: SanitizedBody): string | null {
+  if (sanitized.label) return sanitized.label;
+
+  if (isSpeedyPickup(sanitized.deliveryMethod)) {
+    return (sanitized.speedyOfficeName ?? 'Speedy офис').slice(0, MAX_LABEL);
+  }
+
+  const city = sanitized.city ?? '';
+  const street = sanitized.streetAddress ?? '';
+  if (city && street) {
+    return `${city} - ${street}`.slice(0, MAX_LABEL);
+  }
+
+  return null;
+}
+
+/**
+ * Build the DB insert payload for the resolved delivery method.
+ */
+export function buildAddressInsert(
+  userId: string,
+  sanitized: SanitizedBody,
+): AddressInsert {
+  const label = generateAddressLabel(sanitized);
+
+  if (isSpeedyPickup(sanitized.deliveryMethod)) {
+    return {
+      user_id: userId,
+      delivery_method: sanitized.deliveryMethod,
+      first_name: sanitized.firstName!,
+      last_name: sanitized.lastName!,
+      phone: sanitized.phone || null,
+      speedy_office_id: sanitized.speedyOfficeId!,
+      speedy_office_name: sanitized.speedyOfficeName!,
+      speedy_office_address: sanitized.speedyOfficeAddress || null,
+      label,
+      delivery_notes: sanitized.deliveryNotes || null,
+      is_default: sanitized.isDefault ?? false,
+    };
+  }
+
+  return {
+    user_id: userId,
+    delivery_method: 'address',
+    first_name: sanitized.firstName!,
+    last_name: sanitized.lastName!,
+    city: sanitized.city!,
+    postal_code: sanitized.postalCode!,
+    street_address: sanitized.streetAddress!,
+    label,
+    phone: sanitized.phone || null,
+    building_entrance: sanitized.buildingEntrance || null,
+    floor: sanitized.floor || null,
+    apartment: sanitized.apartment || null,
+    delivery_notes: sanitized.deliveryNotes || null,
+    is_default: sanitized.isDefault ?? false,
+  };
+}
+
+/**
+ * Build the DB update payload for the resolved delivery method.
+ * When switching method, explicitly nulls out fields that no longer apply.
+ */
+export function buildAddressUpdate(sanitized: SanitizedBody): AddressUpdate {
+  if (isSpeedyPickup(sanitized.deliveryMethod)) {
+    return {
+      delivery_method: sanitized.deliveryMethod,
+      first_name: sanitized.firstName!,
+      last_name: sanitized.lastName!,
+      phone: sanitized.phone || null,
+      speedy_office_id: sanitized.speedyOfficeId!,
+      speedy_office_name: sanitized.speedyOfficeName!,
+      speedy_office_address: sanitized.speedyOfficeAddress || null,
+      label: sanitized.label || null,
+      delivery_notes: sanitized.deliveryNotes || null,
+      is_default: sanitized.isDefault ?? false,
+      // Null out home-delivery fields
+      city: null,
+      postal_code: null,
+      street_address: null,
+      building_entrance: null,
+      floor: null,
+      apartment: null,
+    };
+  }
+
+  return {
+    delivery_method: 'address',
+    first_name: sanitized.firstName!,
+    last_name: sanitized.lastName!,
+    city: sanitized.city!,
+    postal_code: sanitized.postalCode!,
+    street_address: sanitized.streetAddress!,
+    label: sanitized.label || null,
+    phone: sanitized.phone || null,
+    building_entrance: sanitized.buildingEntrance || null,
+    floor: sanitized.floor || null,
+    apartment: sanitized.apartment || null,
+    delivery_notes: sanitized.deliveryNotes || null,
+    is_default: sanitized.isDefault ?? false,
+    // Null out Speedy fields
+    speedy_office_id: null,
+    speedy_office_name: null,
+    speedy_office_address: null,
+  };
+}


### PR DESCRIPTION
> 📘 Development workflow: docs/workflow.md  
> 📦 Releases: docs/releases.md  
> 🚑 Hotfixes: docs/hotfixes.md  
> ↩️ Rollback: docs/rollback.md  

---

## Linked Issue
Issue #240 

---

## Type of change
- [x] Bug fix
- [ ] Feature
- [x] Tech debt / Refactor
- [ ] Performance
- [ ] Docs

---

## Description
Staff can now correctly save Speedy automat (parcel locker) addresses when creating or editing addresses on behalf of a customer. Previously the admin address endpoints only recognized Speedy office and silently treated automat selections as an incomplete street address, causing validation errors or incorrect data — the customer-facing flow already handled it. This PR extracts the duplicated address sanitization, validation, delivery-method branching, and DB payload building (spread across four routes, with the admin routes importing helpers from a customer route file) into a single shared lib/order/address-write module, so every delivery method behaves consistently and the logic can no longer drift out of sync.

---

## Target branch checklist
- [x] dev → feature work
- [ ] stage → release candidate
- [ ] main → production only

---

## Release intent
- [ ] This change affects production behavior
- [ ] This change does NOT require a release (docs / infra)

> If this is a Feature or Bug going to `main`, a **changeset is required**  
> unless `skip-release` is explicitly approved.

---

## Versioning
- [x] This PR does NOT bump versions (required unless targeting main)
- [x] This PR includes a changeset (if user-facing change)

---

## Validation
- [x] Build passes
- [ ] Tested on Vercel preview (if applicable)
